### PR TITLE
feat: per-entity OP_SERVICE_ACCOUNT_TOKEN injection

### DIFF
--- a/packages/daemon/src/__tests__/env.test.ts
+++ b/packages/daemon/src/__tests__/env.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { check_required_binaries, propagate_tmux_env, resolve_binary } from "../env.js";
+import {
+  TMUX_PROPAGATED_VARS,
+  check_required_binaries,
+  propagate_tmux_env,
+  resolve_binary,
+} from "../env.js";
 
 describe("check_required_binaries", () => {
   let original_exit: typeof process.exit;
@@ -88,6 +93,27 @@ describe("check_required_binaries", () => {
   });
 });
 
+describe("TMUX_PROPAGATED_VARS", () => {
+  it("does NOT include OP_SERVICE_ACCOUNT_TOKEN (injected per-session by pool.ts)", () => {
+    // Platform token is scoped to the daemon process. Per-entity tokens are
+    // injected by pool.ts::resolve_entity_op_token when a session is spawned.
+    // Propagating here would leak the platform token into every entity session.
+    expect(TMUX_PROPAGATED_VARS).not.toContain("OP_SERVICE_ACCOUNT_TOKEN");
+  });
+
+  it("does NOT include any OP_SERVICE_ACCOUNT_TOKEN_* variant", () => {
+    for (const key of TMUX_PROPAGATED_VARS) {
+      expect(key.startsWith("OP_SERVICE_ACCOUNT_TOKEN")).toBe(false);
+    }
+  });
+
+  it("includes the core process-wide vars (PATH, HOME, BUN_INSTALL)", () => {
+    expect(TMUX_PROPAGATED_VARS).toContain("PATH");
+    expect(TMUX_PROPAGATED_VARS).toContain("HOME");
+    expect(TMUX_PROPAGATED_VARS).toContain("BUN_INSTALL");
+  });
+});
+
 describe("propagate_tmux_env", () => {
   it("calls tmux setter for each present env var", () => {
     const calls: Array<[string, string]> = [];
@@ -100,16 +126,35 @@ describe("propagate_tmux_env", () => {
       PATH: "/usr/bin:/bin",
       HOME: "/Users/test",
       BUN_INSTALL: "/Users/test/.bun",
-      OP_SERVICE_ACCOUNT_TOKEN: "ops_test123",
     };
 
     propagate_tmux_env(env, setter);
 
-    expect(calls).toHaveLength(4);
+    expect(calls).toHaveLength(3);
     expect(calls).toContainEqual(["PATH", "/usr/bin:/bin"]);
     expect(calls).toContainEqual(["HOME", "/Users/test"]);
     expect(calls).toContainEqual(["BUN_INSTALL", "/Users/test/.bun"]);
-    expect(calls).toContainEqual(["OP_SERVICE_ACCOUNT_TOKEN", "ops_test123"]);
+  });
+
+  it("does NOT propagate OP_SERVICE_ACCOUNT_TOKEN even when present in env", () => {
+    const calls: Array<[string, string]> = [];
+    const setter = (key: string, value: string) => {
+      calls.push([key, value]);
+      return true;
+    };
+
+    // Token value is an opaque placeholder — we only assert its KEY doesn't
+    // appear in the propagated calls. Never compare against the raw value.
+    const env = {
+      PATH: "/usr/bin",
+      HOME: "/Users/test",
+      OP_SERVICE_ACCOUNT_TOKEN: "placeholder-should-not-propagate",
+    };
+
+    propagate_tmux_env(env, setter);
+
+    const propagated_keys = calls.map((c) => c[0]);
+    expect(propagated_keys).not.toContain("OP_SERVICE_ACCOUNT_TOKEN");
   });
 
   it("skips env vars that are not set", () => {

--- a/packages/daemon/src/__tests__/pool-op-token.test.ts
+++ b/packages/daemon/src/__tests__/pool-op-token.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for per-entity OP_SERVICE_ACCOUNT_TOKEN resolution.
+ *
+ * Covers:
+ * - entity_id_to_env_suffix: kebab-case, underscores, mixed case, numerics,
+ *   and invalid shapes that can't produce a valid env var name
+ * - resolve_entity_op_token: entity-scoped hit, platform fallback with warning
+ *   + Sentry breadcrumb, and null when neither is available
+ *
+ * Security posture: tests only reason about whether tokens are present /
+ * absent / selected. Raw token values in these tests are opaque placeholders;
+ * we never assert against a real secret and never include one in the
+ * warning-message regex.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { entity_id_to_env_suffix, resolve_entity_op_token } from "../pool.js";
+import * as sentry from "../sentry.js";
+
+describe("entity_id_to_env_suffix", () => {
+  it("upper-cases a lowercase id", () => {
+    expect(entity_id_to_env_suffix("healthydogs")).toBe("HEALTHYDOGS");
+  });
+
+  it("converts kebab-case to underscore (lobster-farm → LOBSTER_FARM)", () => {
+    expect(entity_id_to_env_suffix("lobster-farm")).toBe("LOBSTER_FARM");
+  });
+
+  it("preserves already-underscored ids", () => {
+    expect(entity_id_to_env_suffix("my_entity")).toBe("MY_ENTITY");
+  });
+
+  it("handles mixed case", () => {
+    expect(entity_id_to_env_suffix("MixedCase")).toBe("MIXEDCASE");
+  });
+
+  it("allows embedded digits", () => {
+    expect(entity_id_to_env_suffix("client99")).toBe("CLIENT99");
+  });
+
+  it("replaces non-alphanumeric characters with underscore", () => {
+    expect(entity_id_to_env_suffix("client.99")).toBe("CLIENT_99");
+    expect(entity_id_to_env_suffix("a/b")).toBe("A_B");
+    expect(entity_id_to_env_suffix("foo bar")).toBe("FOO_BAR");
+  });
+
+  it("rejects ids that would produce a digit-leading env var name", () => {
+    // POSIX: env var names must start with a letter or underscore.
+    expect(entity_id_to_env_suffix("99badstart")).toBeNull();
+    expect(entity_id_to_env_suffix("1")).toBeNull();
+  });
+
+  it("rejects empty or non-string input", () => {
+    expect(entity_id_to_env_suffix("")).toBeNull();
+    // Simulate bad data coming off the wire
+    expect(entity_id_to_env_suffix(undefined as unknown as string)).toBeNull();
+    expect(entity_id_to_env_suffix(null as unknown as string)).toBeNull();
+  });
+
+  it("handles a leading underscore id", () => {
+    expect(entity_id_to_env_suffix("_internal")).toBe("_INTERNAL");
+  });
+});
+
+describe("resolve_entity_op_token", () => {
+  let warn_spy: ReturnType<typeof vi.spyOn>;
+  let breadcrumb_spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn_spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    breadcrumb_spy = vi.spyOn(sentry, "addBreadcrumb").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn_spy.mockRestore();
+    breadcrumb_spy.mockRestore();
+  });
+
+  it("returns the entity-scoped token when set", () => {
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN_HEALTHYDOGS: "entity-token-placeholder",
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    const result = resolve_entity_op_token("healthydogs", env);
+
+    expect(result).toBe("entity-token-placeholder");
+    // No warning, no breadcrumb — this is the happy path
+    expect(warn_spy).not.toHaveBeenCalled();
+    expect(breadcrumb_spy).not.toHaveBeenCalled();
+  });
+
+  it("normalizes kebab-case entity ids before lookup", () => {
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN_LOBSTER_FARM: "lf-token-placeholder",
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    expect(resolve_entity_op_token("lobster-farm", env)).toBe("lf-token-placeholder");
+    expect(warn_spy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the platform token with a warning when entity token is missing", () => {
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    const result = resolve_entity_op_token("healthydogs", env);
+
+    expect(result).toBe("platform-token-placeholder");
+
+    // Warning must mention the entity id — and must NOT include any token value.
+    // We match on the message format, not on the secret.
+    expect(warn_spy).toHaveBeenCalledTimes(1);
+    const warn_message = warn_spy.mock.calls[0]?.[0] as string;
+    expect(warn_message).toContain("[pool] WARN");
+    expect(warn_message).toContain("no entity-scoped OP token");
+    expect(warn_message).toContain("healthydogs");
+    expect(warn_message).toContain("falling back to platform token");
+    expect(warn_message).not.toContain("platform-token-placeholder");
+  });
+
+  it("adds a Sentry breadcrumb on the fallback path (no token values)", () => {
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    resolve_entity_op_token("healthydogs", env);
+
+    expect(breadcrumb_spy).toHaveBeenCalledTimes(1);
+    const crumb = breadcrumb_spy.mock.calls[0]?.[0] as {
+      category: string;
+      message: string;
+      level?: string;
+      data?: Record<string, unknown>;
+    };
+    expect(crumb.category).toBe("pool.op-token");
+    expect(crumb.level).toBe("warning");
+    expect(crumb.data).toEqual({ entity_id: "healthydogs", suffix: "HEALTHYDOGS" });
+    // The breadcrumb must not carry the token itself.
+    const serialized = JSON.stringify(crumb);
+    expect(serialized).not.toContain("platform-token-placeholder");
+  });
+
+  it("does not crash when Sentry throws (e.g., misconfigured)", () => {
+    breadcrumb_spy.mockImplementation(() => {
+      throw new Error("sentry not initialized");
+    });
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    // Fallback path must still surface the platform token even if Sentry throws.
+    expect(() => resolve_entity_op_token("healthydogs", env)).not.toThrow();
+    expect(resolve_entity_op_token("healthydogs", env)).toBe("platform-token-placeholder");
+  });
+
+  it("returns null when neither entity-scoped nor platform token is available", () => {
+    const env = {};
+
+    const result = resolve_entity_op_token("healthydogs", env);
+
+    expect(result).toBeNull();
+    // No platform token to fall back to → no warning emitted. Sessions simply
+    // start without op access; warning would be noise.
+    expect(warn_spy).not.toHaveBeenCalled();
+    expect(breadcrumb_spy).not.toHaveBeenCalled();
+  });
+
+  it("returns null for an invalid entity id when only entity-scoped lookup would apply", () => {
+    // Invalid suffix → entity-scoped lookup is skipped. No platform token → null.
+    const env = {};
+    expect(resolve_entity_op_token("99badstart", env)).toBeNull();
+  });
+
+  it("falls back to platform token for an invalid entity id if platform token is present", () => {
+    // Belt-and-suspenders: even if the id is malformed, we still prefer keeping
+    // the session alive on the platform token rather than dying silently.
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    expect(resolve_entity_op_token("99badstart", env)).toBe("platform-token-placeholder");
+    expect(warn_spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to process.env when env is not passed", () => {
+    // Ensure the default parameter actually reads process.env.
+    const key = "OP_SERVICE_ACCOUNT_TOKEN_TEST_DEFAULT_ENV";
+    process.env[key] = "default-env-placeholder";
+    try {
+      expect(resolve_entity_op_token("test-default-env")).toBe("default-env-placeholder");
+    } finally {
+      delete process.env[key];
+    }
+  });
+});

--- a/packages/daemon/src/env.ts
+++ b/packages/daemon/src/env.ts
@@ -15,7 +15,12 @@ const REQUIRED_BINARIES = ["node", "claude", "git", "gh", "tmux", "bun"] as cons
 const RECOMMENDED_BINARIES = ["op"] as const;
 
 // Env vars that must be available in tmux sessions spawned by the pool.
-const TMUX_PROPAGATED_VARS = ["PATH", "HOME", "BUN_INSTALL", "OP_SERVICE_ACCOUNT_TOKEN"] as const;
+//
+// OP_SERVICE_ACCOUNT_TOKEN is intentionally NOT propagated globally. It is
+// injected per-session by pool.ts with the entity-specific token (see
+// resolve_entity_op_token in pool.ts). Propagating it here would leak the
+// platform token into every entity session and break least-privilege.
+export const TMUX_PROPAGATED_VARS = ["PATH", "HOME", "BUN_INSTALL"] as const;
 
 /**
  * Resolve a binary via `which`. Returns true if found, false otherwise.

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -76,6 +76,79 @@ export interface PoolStatus {
 /** Activity state computed on demand from observable signals (tmux pane, timestamps). */
 export type ActivityState = "idle" | "working" | "waiting_for_human" | "active_conversation";
 
+// ── Per-entity OP_SERVICE_ACCOUNT_TOKEN resolution ──
+
+/**
+ * Normalize an entity id into the suffix used for the per-entity token env
+ * var: `OP_SERVICE_ACCOUNT_TOKEN_<SUFFIX>`.
+ *
+ * Env var names are restricted to `[A-Z0-9_]` in practice, so we upper-case
+ * and convert any non-alphanumeric character to an underscore. The result is
+ * further validated to start with a letter or underscore (POSIX rule). An
+ * empty / invalid entity id returns null — callers treat that as "no token".
+ *
+ * Examples:
+ *   "lobster-farm"  → "LOBSTER_FARM"
+ *   "healthydogs"   → "HEALTHYDOGS"
+ *   "my_entity"     → "MY_ENTITY"
+ *   "client.99"     → "CLIENT_99"
+ *   "99badstart"    → null   (env var can't begin with a digit)
+ *   ""              → null
+ */
+export function entity_id_to_env_suffix(entity_id: string): string | null {
+  if (typeof entity_id !== "string" || entity_id.length === 0) return null;
+  const suffix = entity_id.toUpperCase().replace(/[^A-Z0-9_]/g, "_");
+  if (!/^[A-Z_][A-Z0-9_]*$/.test(suffix)) return null;
+  return suffix;
+}
+
+/**
+ * Resolve the OP_SERVICE_ACCOUNT_TOKEN value to inject into a tmux session
+ * spawned for `entity_id`.
+ *
+ * Lookup order:
+ *   1. `OP_SERVICE_ACCOUNT_TOKEN_<ENTITY_SUFFIX>` — the entity-scoped token
+ *   2. `OP_SERVICE_ACCOUNT_TOKEN`                 — platform fallback (with warning)
+ *
+ * Returns `null` if neither is set; the session spawns without `op` access.
+ *
+ * The fallback path logs a warning and adds a Sentry breadcrumb. Neither
+ * surface contains the token value — only the entity id and the suffix
+ * that was looked up.
+ */
+export function resolve_entity_op_token(
+  entity_id: string,
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  const suffix = entity_id_to_env_suffix(entity_id);
+  if (suffix) {
+    const scoped = env[`OP_SERVICE_ACCOUNT_TOKEN_${suffix}`];
+    if (scoped) return scoped;
+  }
+
+  const platform = env.OP_SERVICE_ACCOUNT_TOKEN;
+  if (platform) {
+    console.warn(
+      `[pool] WARN: no entity-scoped OP token for ${entity_id}, falling back to platform token`,
+    );
+    // Sentry is a no-op if not initialized (see sentry.ts) — safe to always call.
+    try {
+      sentry.addBreadcrumb({
+        category: "pool.op-token",
+        message: "entity-scoped OP token missing, fell back to platform token",
+        level: "warning",
+        data: { entity_id, suffix: suffix ?? null },
+      });
+    } catch {
+      // Never let a Sentry misconfig break session startup. The warning above
+      // is the operator's source of truth.
+    }
+    return platform;
+  }
+
+  return null;
+}
+
 // ── Tmux idle detection ──
 
 /**
@@ -822,6 +895,15 @@ export class BotPool extends EventEmitter {
           }
         }
 
+        // Per-entity 1Password token. Falls back to the platform token with
+        // a warning if no entity-scoped token is configured (see
+        // resolve_entity_op_token). Null means neither is set — the agent
+        // session will simply lack `op` access until tokens are wired.
+        const op_token = resolve_entity_op_token(candidate.entity_id);
+        if (op_token) {
+          extra_env.OP_SERVICE_ACCOUNT_TOKEN = op_token;
+        }
+
         // Write a resume-nudge pending message and point LF_PENDING_FILE at
         // it. The SessionStart hook (session-start-inject.sh) delivers it
         // during Claude init as additionalContext — replacing the legacy
@@ -1093,6 +1175,11 @@ export class BotPool extends EventEmitter {
           console.warn(`[pool] Failed to resolve GH_TOKEN for ${entity_id}: ${String(err)}`);
           // Non-fatal: session starts without GH_TOKEN
         }
+      }
+
+      const assign_op_token = resolve_entity_op_token(entity_id);
+      if (assign_op_token) {
+        extra_env.OP_SERVICE_ACCOUNT_TOKEN = assign_op_token;
       }
 
       // If a pending message was provided, write it to the JSON file and
@@ -1689,6 +1776,11 @@ export class BotPool extends EventEmitter {
         } catch (err) {
           console.warn(`[pool] Failed to resolve GH_TOKEN for ${entity_id}: ${String(err)}`);
         }
+      }
+
+      const crash_op_token = resolve_entity_op_token(entity_id);
+      if (crash_op_token) {
+        extra_env.OP_SERVICE_ACCOUNT_TOKEN = crash_op_token;
       }
 
       // Write access.json so the Discord plugin listens on this channel


### PR DESCRIPTION
## Summary

- Phase 2 of per-entity 1Password vault isolation. Daemon no longer propagates the platform `OP_SERVICE_ACCOUNT_TOKEN` into every tmux session — it now picks the entity-scoped token per session.
- New helpers in `pool.ts`: `entity_id_to_env_suffix` (kebab/mixed/numeric → safe POSIX env var name, rejects digit-leading shapes) and `resolve_entity_op_token` (entity token → platform fallback with `console.warn` + guarded Sentry breadcrumb → `null`). Wired into all three `extra_env` build sites: resume, assign, crash-restart.
- `env.ts`: drop `OP_SERVICE_ACCOUNT_TOKEN` from `TMUX_PROPAGATED_VARS` and export the list for tests.

## Security posture

- Fallback `console.warn` names the entity id only, never the token value.
- Sentry breadcrumb carries `entity_id` + `suffix` only; no token material.
- Sentry call is wrapped so a misconfigured/uninitialized Sentry can never block the fallback path (sessions always come up).
- Test assertions match the warning message format, not the secret; all test token values are opaque placeholders.

## Out-of-band change

`~/.lobsterfarm/env.sh` (not in this repo — user-managed, generated by `lf start`) is updated on this machine to stop `unset`ing the per-entity token vars and to use `set -a` so new entity tokens are auto-exported. The daemon currently running ships an older env.sh; it will pick up the new flow on the next session-boundary restart. Noted in today's daily log.

## Test plan

- [x] `pnpm run test` on the daemon package — 1044 pass (1 pre-existing flake in `session-start-hook.test.ts` caused by ambient `LF_PENDING_FILE` in the agent's own env; passes under `env -u LF_PENDING_FILE`)
- [x] 18 new tests in `pool-op-token.test.ts` cover suffix normalization (8 shapes), entity-token hit, platform fallback (warning + breadcrumb, no token value in either surface), Sentry-throws resilience, null when neither token is set, and `process.env` default
- [x] `env.test.ts` asserts `OP_SERVICE_ACCOUNT_TOKEN` is absent from `TMUX_PROPAGATED_VARS` and is never propagated even when present in env
- [x] `pnpm run typecheck` clean across workspace
- [x] `pnpm run lint` (biome) clean
- [ ] Manual verification: spawn a session for `healthydogs` after daemon restart, `op whoami` from inside the tmux session resolves to the `entity-healthydogs` SA (blocked on a session-boundary daemon restart — not doing it inside this feature per the dogfooding caveat)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)