### PR TITLE
fix(daemon): scrub ambient env in session-start-hook tests

### DIFF
--- a/packages/daemon/src/__tests__/session-start-hook.test.ts
+++ b/packages/daemon/src/__tests__/session-start-hook.test.ts
@@ -40,10 +40,20 @@ try {
 
 // ── Helpers ──
 
-/** Invoke the hook script with the given env. Returns stdout + exit code. */
+/**
+ * Invoke the hook script with an explicit, minimal env. Returns stdout + exit
+ * code.
+ *
+ * We deliberately do NOT spread `process.env` here. The hook's only contract
+ * input is `LF_PENDING_FILE`, and if the test runner shell has that variable
+ * exported (as happens inside a live LobsterFarm daemon session), it leaks
+ * into every case that doesn't explicitly override it — silently breaking
+ * the "no-op when unset" assertions. The only ambient var we need is PATH so
+ * bash can resolve `jq`.
+ */
 function run_hook(env: Record<string, string>): { stdout: string; stderr: string; code: number } {
   const result = spawnSync("bash", [HOOK_SCRIPT], {
-    env: { ...process.env, ...env },
+    env: { PATH: process.env.PATH ?? "", ...env },
     encoding: "utf-8",
     timeout: 5000,
   });


### PR DESCRIPTION
## Summary

- `run_hook` helper spread `process.env` into the subprocess, so an ambient `LF_PENDING_FILE` (present inside any live LobsterFarm daemon session) leaked into every case that didn't override it. The "no-op when unset" assertion (line 160) would then fail because the hook happily consumed the host's pending file.
- Fix is one-file, scoped to the test helper: pass an explicit minimal env (`PATH` + caller-provided overrides) to `spawnSync`. No changes to the hook implementation. No mutation of global `process.env` in tests.
- All 10 cases in `session-start-hook.test.ts` now default to a scrubbed env — future cases added through this helper inherit the safe default automatically.

## Test plan

- [x] `LF_PENDING_FILE=/tmp/fake-pending pnpm exec vitest run session-start-hook` in `packages/daemon` — 10/10 pass
- [x] `LF_PENDING_FILE=/tmp/fake-pending pnpm test` from repo root — 1044/1044 pass
- [x] Plain `pnpm test` — 1044/1044 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean

## Cases touched

All test cases in `packages/daemon/src/__tests__/session-start-hook.test.ts` route through the single `run_hook` helper, so the fix covers every case uniformly:

1. `emits SessionStart hook output when pending file is valid JSON`
2. `handles multiline content correctly (JSON escaping)`
3. `handles special chars in content without breaking JSON output`
4. `unlinks the pending file after successful read`
5. `no-ops silently (exit 0, empty stdout) when LF_PENDING_FILE is unset` — the root-cause case
6. `no-ops silently when LF_PENDING_FILE points at a missing file`
7. `no-ops and cleans up when the file is empty`
8. `no-ops (but cleans up) when content field is empty`
9. `no-ops gracefully (exit 0) when file contains invalid JSON`
10. `falls back to 'a user' when the user field is missing`

## Candidates for a future pass (not fixed here — per scope)

Scanned sibling daemon test files for the same class of ambient-env leak. A few tests mutate `process.env` globally for the test process itself (not subprocess env) without always restoring it in `afterEach`:

- `packages/daemon/src/__tests__/queue.test.ts` — sets/deletes `process.env.CLAUDE_BIN` per-test without a saved-and-restored original.
- `packages/daemon/src/__tests__/queue-depth.test.ts` — same pattern as above.
- `packages/daemon/src/__tests__/session.test.ts` — same pattern, multiple cases.
- `packages/daemon/src/__tests__/sentry-triage.test.ts` — sets `SENTRY_AUTH_TOKEN`/`SENTRY_ORG` at the top level of the file; a `beforeEach` assigns them but one `delete` path can leave state set if a test fails mid-way.
- `packages/daemon/src/__tests__/env.test.ts` — mutates `process.env.PATH` and restores manually; works today but a thrown assertion between set and restore would leak.

`github-app.test.ts` does this correctly (`ORIGINAL_ENV = { ...process.env }` + `afterEach` full restore) — good reference pattern.

The sibling `session-start-inject.test.ts` mocks `spawn` entirely, so it has no real subprocess to leak env into. Not affected.

Closes #4