### PR TITLE
fix(daemon-tests): apply env save/restore pattern to 5 sibling files

### DIFF
--- a/packages/daemon/src/__tests__/env.test.ts
+++ b/packages/daemon/src/__tests__/env.test.ts
@@ -6,6 +6,19 @@ import {
   resolve_binary,
 } from "../env.js";
 
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  // Remove any keys added during the test
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  }
+  // Restore any keys mutated or deleted during the test
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    process.env[key] = value;
+  }
+});
+
 describe("check_required_binaries", () => {
   let original_exit: typeof process.exit;
   let exit_code: number | undefined;
@@ -57,7 +70,6 @@ describe("check_required_binaries", () => {
 
   it("logs the current PATH on failure for debugging", () => {
     const error_spy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const original_path = process.env.PATH;
     process.env.PATH = "/test/path:/usr/bin";
 
     // Fail "claude"
@@ -72,7 +84,6 @@ describe("check_required_binaries", () => {
     expect(error_spy).toHaveBeenCalledWith(expect.stringContaining("/test/path:/usr/bin"));
 
     error_spy.mockRestore();
-    process.env.PATH = original_path;
   });
 
   it("lists all missing required binaries in the error message", () => {

--- a/packages/daemon/src/__tests__/queue-depth.test.ts
+++ b/packages/daemon/src/__tests__/queue-depth.test.ts
@@ -7,6 +7,19 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { QueueFullError, TaskQueue } from "../queue.js";
 import { ClaudeSessionManager } from "../session.js";
 
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  // Remove any keys added during the test
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  }
+  // Restore any keys mutated or deleted during the test
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    process.env[key] = value;
+  }
+});
+
 function make_config(overrides?: Record<string, unknown>): LobsterFarmConfig {
   return LobsterFarmConfigSchema.parse({
     user: { name: "Test" },
@@ -37,7 +50,6 @@ describe("Queue depth enforcement", () => {
 
   afterEach(async () => {
     await rm(tmp, { recursive: true, force: true });
-    delete process.env.CLAUDE_BIN;
   });
 
   describe("TaskQueue.submit() with max_queue_depth", () => {

--- a/packages/daemon/src/__tests__/queue.test.ts
+++ b/packages/daemon/src/__tests__/queue.test.ts
@@ -7,6 +7,19 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { TaskQueue } from "../queue.js";
 import { ClaudeSessionManager } from "../session.js";
 
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  // Remove any keys added during the test
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  }
+  // Restore any keys mutated or deleted during the test
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    process.env[key] = value;
+  }
+});
+
 function make_config(overrides?: Record<string, unknown>): LobsterFarmConfig {
   return LobsterFarmConfigSchema.parse({
     user: { name: "Test" },
@@ -37,7 +50,6 @@ describe("TaskQueue", () => {
 
   afterEach(async () => {
     await rm(tmp, { recursive: true, force: true });
-    delete process.env.CLAUDE_BIN;
   });
 
   it("submits a task and returns an ID", () => {

--- a/packages/daemon/src/__tests__/sentry-triage.test.ts
+++ b/packages/daemon/src/__tests__/sentry-triage.test.ts
@@ -166,6 +166,19 @@ function make_context(overrides: Partial<SentryTriageContext> = {}): SentryTriag
 
 // ── Setup ──
 
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  // Remove any keys added during the test
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  }
+  // Restore any keys mutated or deleted during the test
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    process.env[key] = value;
+  }
+});
+
 beforeEach(async () => {
   vi.clearAllMocks();
   vi.spyOn(console, "log").mockImplementation(() => {});
@@ -187,9 +200,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(temp_dir, { recursive: true, force: true });
-  delete process.env.SENTRY_AUTH_TOKEN;
-  delete process.env.SENTRY_ORG;
-
   vi.restoreAllMocks();
 });
 

--- a/packages/daemon/src/__tests__/session.test.ts
+++ b/packages/daemon/src/__tests__/session.test.ts
@@ -7,6 +7,19 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { build_model_flags } from "../models.js";
 import { ClaudeSessionManager } from "../session.js";
 
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  // Remove any keys added during the test
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  }
+  // Restore any keys mutated or deleted during the test
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    process.env[key] = value;
+  }
+});
+
 function make_config(overrides?: Partial<LobsterFarmConfig>): LobsterFarmConfig {
   return LobsterFarmConfigSchema.parse({
     user: { name: "Test" },
@@ -211,8 +224,6 @@ describe("ClaudeSessionManager", () => {
 
       // After completion, session should be cleaned up
       expect(mgr.get_active()).toHaveLength(0);
-
-      delete process.env.CLAUDE_BIN;
     });
 
     it("rejects interactive mode", async () => {
@@ -260,8 +271,6 @@ describe("ClaudeSessionManager", () => {
       const error = await failed;
       expect(error).toContain("exited with code 1");
       expect(mgr.get_active()).toHaveLength(0);
-
-      delete process.env.CLAUDE_BIN;
     });
   });
 
@@ -297,8 +306,6 @@ describe("ClaudeSessionManager", () => {
       await mgr.kill(session.session_id);
       await wait_for(() => mgr.get_active().length === 0);
       expect(mgr.get_active()).toHaveLength(0);
-
-      delete process.env.CLAUDE_BIN;
     });
   });
 });


### PR DESCRIPTION
## Summary

Apply the canonical env save/restore pattern from `github-app.test.ts` to five daemon test files that mutated `process.env` without a guard:

- `packages/daemon/src/__tests__/queue.test.ts`
- `packages/daemon/src/__tests__/queue-depth.test.ts`
- `packages/daemon/src/__tests__/session.test.ts`
- `packages/daemon/src/__tests__/sentry-triage.test.ts`
- `packages/daemon/src/__tests__/env.test.ts`

Each file now snapshots `process.env` at module load and restores exactly in an `afterEach`. A mid-test throw can no longer leak env state into sibling tests.

## What changed

- Added module-top `const ORIGINAL_ENV = { ...process.env }` + `afterEach` restore block (matching the spec's canonical shape) to all five files.
- Removed ad-hoc partial restores that the canonical pattern subsumes, per the issue's explicit "do not layer the canonical on top of ad-hoc restore" guidance:
  - `delete process.env.CLAUDE_BIN` from the describe-scoped `afterEach` in `queue.test.ts` and `queue-depth.test.ts`.
  - `delete process.env.CLAUDE_BIN` at the end of three test bodies in `session.test.ts`.
  - `delete process.env.SENTRY_AUTH_TOKEN` / `delete process.env.SENTRY_ORG` from the module-scoped `afterEach` in `sentry-triage.test.ts`.
  - The inline `const original_path = process.env.PATH` / `process.env.PATH = original_path` save/restore in the "logs the current PATH on failure" test in `env.test.ts`.
- No assertions changed. No test cases renamed, reordered, added, or removed. No tested code touched. No helper extracted.

## Notes

- The live `github-app.test.ts` reference uses a slightly different shape (`ORIGINAL_ENV` inside a `describe`, restored via `afterAll`, with `beforeEach` wiping specific keys). That shape works for that file because `beforeEach` already zeroes the mutated keys. For these five files — which mutate a broader and more variable set of keys per test — the issue's acceptance criteria ("no test leaves `process.env` in a mutated state after it completes, including on throw") is stronger than `afterAll` provides. I followed the issue's `afterEach` wording and the workflow's explicit step-4 instruction.
- The `sentry-triage.test.ts` test "skips triage when SENTRY_AUTH_TOKEN is not set" intentionally deletes `SENTRY_AUTH_TOKEN` in the test body. Under the canonical pattern the `afterEach` restores it (to whatever was in the host env at module load, which `beforeEach` then overwrites to `"test-token"` for the next test). Verified it still passes.
- None of the five files were already correctly guarded — all five needed the pattern applied.
- Did not find additional sibling files with the same smell while scoped to these five. If more surface later, fix in a follow-up pass.

## Verification

- `FAKE_SPURIOUS=1 EXTRA_JUNK=x pnpm exec vitest run src/__tests__/{queue,queue-depth,session,sentry-triage,env}.test.ts` (in `packages/daemon`) — 85/85 pass.
- `pnpm exec vitest run` (full daemon suite) — 1044/1044 pass.
- `pnpm test` (full workspace) — all green.
- Ran the five files back-to-back twice: identical 85/85 pass count, no state leakage between runs.
- `pnpm typecheck` — clean.
- `pnpm lint` — clean.

Closes #7

## Test plan

- [x] All five target files modified
- [x] Each captures `ORIGINAL_ENV` once and restores in `afterEach`
- [x] No test leaves `process.env` mutated post-run
- [x] All existing assertions pass unchanged
- [x] Green under env-polluted invocation
- [x] No new abstractions / no shared helper extracted

Generated with Claude Code