### PR TITLE
chore: ignore agent worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ coverage/
 # Turborepo
 .turbo/
 .claude/
+
+# Agent worktrees
+worktrees/


### PR DESCRIPTION
## Summary

Adds `worktrees/` to `.gitignore` so agent-created feature worktrees under `~/.lobsterfarm/src/worktrees/` stop appearing as untracked noise in `git status` from the repo root.

Tiny cleanup from the 2026-04-18 Phase 2 rollout session — below the issue-threshold per the feature-lifecycle skill (a one-line `.gitignore` change is not a non-trivial feature).

## Test plan

- [x] Verified `worktrees/` was not already ignored
- [x] Confirmed `git check-ignore -v worktrees/` matches the new rule
- [x] Confirmed `git status` in the feature worktree shows only `.gitignore` modified

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>