### PR TITLE
fix(pool): resolve_entity_op_token tries both underscore and stripped suffixes

### DIFF
--- a/packages/daemon/src/__tests__/pool-op-token.test.ts
+++ b/packages/daemon/src/__tests__/pool-op-token.test.ts
@@ -3,9 +3,12 @@
  *
  * Covers:
  * - entity_id_to_env_suffix: kebab-case, underscores, mixed case, numerics,
- *   and invalid shapes that can't produce a valid env var name
- * - resolve_entity_op_token: entity-scoped hit, platform fallback with warning
- *   + Sentry breadcrumb, and null when neither is available
+ *   and invalid shapes that can't produce a valid env var name. Returns an
+ *   ordered, deduped list of candidate suffixes (underscore form first,
+ *   stripped form second) — see issue #13.
+ * - resolve_entity_op_token: entity-scoped hit (either candidate), platform
+ *   fallback with warning + Sentry breadcrumb, and null when neither is
+ *   available.
  *
  * Security posture: tests only reason about whether tokens are present /
  * absent / selected. Raw token values in these tests are opaque placeholders;
@@ -18,47 +21,55 @@ import { entity_id_to_env_suffix, resolve_entity_op_token } from "../pool.js";
 import * as sentry from "../sentry.js";
 
 describe("entity_id_to_env_suffix", () => {
-  it("upper-cases a lowercase id", () => {
-    expect(entity_id_to_env_suffix("healthydogs")).toBe("HEALTHYDOGS");
+  it("returns a single candidate for a lowercase id with no hyphens", () => {
+    expect(entity_id_to_env_suffix("healthydogs")).toEqual(["HEALTHYDOGS"]);
   });
 
-  it("converts kebab-case to underscore (lobster-farm → LOBSTER_FARM)", () => {
-    expect(entity_id_to_env_suffix("lobster-farm")).toBe("LOBSTER_FARM");
+  it("returns [underscore, stripped] for kebab-case (lobster-farm)", () => {
+    // Underscore form is first so it wins when both tokens exist.
+    expect(entity_id_to_env_suffix("lobster-farm")).toEqual(["LOBSTER_FARM", "LOBSTERFARM"]);
   });
 
-  it("preserves already-underscored ids", () => {
-    expect(entity_id_to_env_suffix("my_entity")).toBe("MY_ENTITY");
+  it("returns both candidates for multi-hyphen ids, deduped order preserved", () => {
+    expect(entity_id_to_env_suffix("a-b-c")).toEqual(["A_B_C", "ABC"]);
   });
 
-  it("handles mixed case", () => {
-    expect(entity_id_to_env_suffix("MixedCase")).toBe("MIXEDCASE");
+  it("dedupes when underscore and stripped forms are identical", () => {
+    expect(entity_id_to_env_suffix("my_entity")).toEqual(["MY_ENTITY"]);
+    expect(entity_id_to_env_suffix("MixedCase")).toEqual(["MIXEDCASE"]);
+    expect(entity_id_to_env_suffix("client99")).toEqual(["CLIENT99"]);
   });
 
-  it("allows embedded digits", () => {
-    expect(entity_id_to_env_suffix("client99")).toBe("CLIENT99");
-  });
-
-  it("replaces non-alphanumeric characters with underscore", () => {
-    expect(entity_id_to_env_suffix("client.99")).toBe("CLIENT_99");
-    expect(entity_id_to_env_suffix("a/b")).toBe("A_B");
-    expect(entity_id_to_env_suffix("foo bar")).toBe("FOO_BAR");
+  it("replaces non-alphanumeric, non-hyphen characters with underscore in both forms", () => {
+    // Dots / slashes / spaces are not hyphens — they become underscores in
+    // both the explicit and compact candidates, which dedupes to one entry.
+    expect(entity_id_to_env_suffix("client.99")).toEqual(["CLIENT_99"]);
+    expect(entity_id_to_env_suffix("a/b")).toEqual(["A_B"]);
+    expect(entity_id_to_env_suffix("foo bar")).toEqual(["FOO_BAR"]);
   });
 
   it("rejects ids that would produce a digit-leading env var name", () => {
-    // POSIX: env var names must start with a letter or underscore.
-    expect(entity_id_to_env_suffix("99badstart")).toBeNull();
-    expect(entity_id_to_env_suffix("1")).toBeNull();
+    // POSIX: env var names must start with a letter or underscore. Both
+    // candidates fail validation → empty list.
+    expect(entity_id_to_env_suffix("99badstart")).toEqual([]);
+    expect(entity_id_to_env_suffix("1")).toEqual([]);
   });
 
   it("rejects empty or non-string input", () => {
-    expect(entity_id_to_env_suffix("")).toBeNull();
+    expect(entity_id_to_env_suffix("")).toEqual([]);
     // Simulate bad data coming off the wire
-    expect(entity_id_to_env_suffix(undefined as unknown as string)).toBeNull();
-    expect(entity_id_to_env_suffix(null as unknown as string)).toBeNull();
+    expect(entity_id_to_env_suffix(undefined as unknown as string)).toEqual([]);
+    expect(entity_id_to_env_suffix(null as unknown as string)).toEqual([]);
   });
 
   it("handles a leading underscore id", () => {
-    expect(entity_id_to_env_suffix("_internal")).toBe("_INTERNAL");
+    expect(entity_id_to_env_suffix("_internal")).toEqual(["_INTERNAL"]);
+  });
+
+  it("drops a stripped candidate that becomes digit-leading", () => {
+    // "12-foo" → underscore form "12_FOO" is invalid; stripped "12FOO" also
+    // invalid. Both filtered → empty.
+    expect(entity_id_to_env_suffix("12-foo")).toEqual([]);
   });
 });
 
@@ -76,7 +87,7 @@ describe("resolve_entity_op_token", () => {
     breadcrumb_spy.mockRestore();
   });
 
-  it("returns the entity-scoped token when set", () => {
+  it("returns the entity-scoped token when set (no-hyphen id)", () => {
     const env = {
       OP_SERVICE_ACCOUNT_TOKEN_HEALTHYDOGS: "entity-token-placeholder",
       OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
@@ -90,17 +101,84 @@ describe("resolve_entity_op_token", () => {
     expect(breadcrumb_spy).not.toHaveBeenCalled();
   });
 
-  it("normalizes kebab-case entity ids before lookup", () => {
+  it("resolves the underscore form when only the underscore token is set", () => {
     const env = {
-      OP_SERVICE_ACCOUNT_TOKEN_LOBSTER_FARM: "lf-token-placeholder",
+      OP_SERVICE_ACCOUNT_TOKEN_LOBSTER_FARM: "lf-underscore-placeholder",
       OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
     };
 
-    expect(resolve_entity_op_token("lobster-farm", env)).toBe("lf-token-placeholder");
+    expect(resolve_entity_op_token("lobster-farm", env)).toBe("lf-underscore-placeholder");
+    expect(warn_spy).not.toHaveBeenCalled();
+    expect(breadcrumb_spy).not.toHaveBeenCalled();
+  });
+
+  it("resolves the stripped form when only the stripped token is set (issue #13)", () => {
+    // This is the live bug: lobster-farm's token is stored as LOBSTERFARM.
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN_LOBSTERFARM: "lf-stripped-placeholder",
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    expect(resolve_entity_op_token("lobster-farm", env)).toBe("lf-stripped-placeholder");
+    expect(warn_spy).not.toHaveBeenCalled();
+    expect(breadcrumb_spy).not.toHaveBeenCalled();
+  });
+
+  it("prefers the underscore form when both are set (explicit wins)", () => {
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN_LOBSTER_FARM: "lf-underscore-placeholder",
+      OP_SERVICE_ACCOUNT_TOKEN_LOBSTERFARM: "lf-stripped-placeholder",
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    expect(resolve_entity_op_token("lobster-farm", env)).toBe("lf-underscore-placeholder");
     expect(warn_spy).not.toHaveBeenCalled();
   });
 
-  it("falls back to the platform token with a warning when entity token is missing", () => {
+  it("falls back to platform token when neither candidate form is set", () => {
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    const result = resolve_entity_op_token("lobster-farm", env);
+
+    expect(result).toBe("platform-token-placeholder");
+    expect(warn_spy).toHaveBeenCalledTimes(1);
+    const warn_message = warn_spy.mock.calls[0]?.[0] as string;
+    expect(warn_message).toContain("[pool] WARN");
+    expect(warn_message).toContain("no entity-scoped OP token");
+    expect(warn_message).toContain("lobster-farm");
+    expect(warn_message).toContain("falling back to platform token");
+    expect(warn_message).not.toContain("platform-token-placeholder");
+  });
+
+  it("collision: lobster-farm and lobsterfarm both resolve to LOBSTERFARM when that's the only token", () => {
+    // Documents the known Option-A collision (see issue #13): a machine with
+    // only OP_SERVICE_ACCOUNT_TOKEN_LOBSTERFARM set serves both entity ids
+    // from the same token because "lobsterfarm" → ["LOBSTERFARM"] and
+    // "lobster-farm" → ["LOBSTER_FARM", "LOBSTERFARM"].
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN_LOBSTERFARM: "shared-token-placeholder",
+    };
+
+    expect(resolve_entity_op_token("lobsterfarm", env)).toBe("shared-token-placeholder");
+    expect(resolve_entity_op_token("lobster-farm", env)).toBe("shared-token-placeholder");
+  });
+
+  it("collision: if a LOBSTER_FARM-specific token exists, it wins for lobster-farm only", () => {
+    // The inverse: hyphenated id gets its explicit token; compact id still
+    // falls back since LOBSTERFARM isn't set.
+    const env = {
+      OP_SERVICE_ACCOUNT_TOKEN_LOBSTER_FARM: "hyphen-specific-placeholder",
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    expect(resolve_entity_op_token("lobster-farm", env)).toBe("hyphen-specific-placeholder");
+    // lobsterfarm has no LOBSTERFARM token → fallback.
+    expect(resolve_entity_op_token("lobsterfarm", env)).toBe("platform-token-placeholder");
+  });
+
+  it("falls back to the platform token with a warning when entity token is missing (no-hyphen)", () => {
     const env = {
       OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
     };
@@ -109,8 +187,6 @@ describe("resolve_entity_op_token", () => {
 
     expect(result).toBe("platform-token-placeholder");
 
-    // Warning must mention the entity id — and must NOT include any token value.
-    // We match on the message format, not on the secret.
     expect(warn_spy).toHaveBeenCalledTimes(1);
     const warn_message = warn_spy.mock.calls[0]?.[0] as string;
     expect(warn_message).toContain("[pool] WARN");
@@ -120,12 +196,12 @@ describe("resolve_entity_op_token", () => {
     expect(warn_message).not.toContain("platform-token-placeholder");
   });
 
-  it("adds a Sentry breadcrumb on the fallback path (no token values)", () => {
+  it("adds a Sentry breadcrumb on the fallback path listing all tried suffixes", () => {
     const env = {
       OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
     };
 
-    resolve_entity_op_token("healthydogs", env);
+    resolve_entity_op_token("lobster-farm", env);
 
     expect(breadcrumb_spy).toHaveBeenCalledTimes(1);
     const crumb = breadcrumb_spy.mock.calls[0]?.[0] as {
@@ -136,10 +212,26 @@ describe("resolve_entity_op_token", () => {
     };
     expect(crumb.category).toBe("pool.op-token");
     expect(crumb.level).toBe("warning");
-    expect(crumb.data).toEqual({ entity_id: "healthydogs", suffix: "HEALTHYDOGS" });
+    expect(crumb.data).toEqual({
+      entity_id: "lobster-farm",
+      suffixes_tried: ["LOBSTER_FARM", "LOBSTERFARM"],
+    });
     // The breadcrumb must not carry the token itself.
     const serialized = JSON.stringify(crumb);
     expect(serialized).not.toContain("platform-token-placeholder");
+  });
+
+  it("breadcrumb for a no-hyphen id lists a single suffix", () => {
+    const env = { OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder" };
+    resolve_entity_op_token("healthydogs", env);
+
+    const crumb = breadcrumb_spy.mock.calls[0]?.[0] as {
+      data?: Record<string, unknown>;
+    };
+    expect(crumb.data).toEqual({
+      entity_id: "healthydogs",
+      suffixes_tried: ["HEALTHYDOGS"],
+    });
   });
 
   it("does not crash when Sentry throws (e.g., misconfigured)", () => {
@@ -150,7 +242,6 @@ describe("resolve_entity_op_token", () => {
       OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
     };
 
-    // Fallback path must still surface the platform token even if Sentry throws.
     expect(() => resolve_entity_op_token("healthydogs", env)).not.toThrow();
     expect(resolve_entity_op_token("healthydogs", env)).toBe("platform-token-placeholder");
   });
@@ -168,7 +259,7 @@ describe("resolve_entity_op_token", () => {
   });
 
   it("returns null for an invalid entity id when only entity-scoped lookup would apply", () => {
-    // Invalid suffix → entity-scoped lookup is skipped. No platform token → null.
+    // Invalid suffix list (empty) → entity-scoped lookup is skipped. No platform token → null.
     const env = {};
     expect(resolve_entity_op_token("99badstart", env)).toBeNull();
   });

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -79,27 +79,55 @@ export type ActivityState = "idle" | "working" | "waiting_for_human" | "active_c
 // ── Per-entity OP_SERVICE_ACCOUNT_TOKEN resolution ──
 
 /**
- * Normalize an entity id into the suffix used for the per-entity token env
- * var: `OP_SERVICE_ACCOUNT_TOKEN_<SUFFIX>`.
+ * Normalize an entity id into the ordered list of candidate suffixes used for
+ * per-entity token env vars: `OP_SERVICE_ACCOUNT_TOKEN_<SUFFIX>`.
+ *
+ * Two conventions exist in the wild and must both be tried:
+ *   1. kebab → underscore (explicit):  "lobster-farm" → "LOBSTER_FARM"
+ *   2. kebab → stripped    (compact):  "lobster-farm" → "LOBSTERFARM"
+ *
+ * The underscore form is listed first so it wins when both are populated —
+ * it's the explicit, unambiguous form. The stripped form is included because
+ * the live secrets file (`~/.lobsterfarm/secrets/op-tokens.env`) was seeded
+ * with that convention and we don't want to force a rename (see issue #13).
+ *
+ * For entity ids without hyphens (e.g. "healthydogs"), both candidates
+ * collapse to the same value — we dedupe so callers do one env lookup.
  *
  * Env var names are restricted to `[A-Z0-9_]` in practice, so we upper-case
- * and convert any non-alphanumeric character to an underscore. The result is
- * further validated to start with a letter or underscore (POSIX rule). An
- * empty / invalid entity id returns null — callers treat that as "no token".
+ * and convert any non-alphanumeric character to an underscore. Each candidate
+ * is validated to start with a letter or underscore (POSIX rule). An empty /
+ * invalid entity id returns an empty array — callers treat that as "no token".
  *
  * Examples:
- *   "lobster-farm"  → "LOBSTER_FARM"
- *   "healthydogs"   → "HEALTHYDOGS"
- *   "my_entity"     → "MY_ENTITY"
- *   "client.99"     → "CLIENT_99"
- *   "99badstart"    → null   (env var can't begin with a digit)
- *   ""              → null
+ *   "lobster-farm"  → ["LOBSTER_FARM", "LOBSTERFARM"]
+ *   "healthydogs"   → ["HEALTHYDOGS"]
+ *   "my_entity"     → ["MY_ENTITY"]
+ *   "client.99"     → ["CLIENT_99"]        (dot → underscore, strip leaves same)
+ *   "99badstart"    → []                   (env var can't begin with a digit)
+ *   ""              → []
+ *
+ * Collision note: `lobster-farm` and `lobsterfarm` both contain `LOBSTERFARM`
+ * in their candidate list. If only `OP_SERVICE_ACCOUNT_TOKEN_LOBSTERFARM` is
+ * set on the machine, both entity ids will resolve to the same token. This
+ * is accepted — see the issue #13 collision test for the assertion.
  */
-export function entity_id_to_env_suffix(entity_id: string): string | null {
-  if (typeof entity_id !== "string" || entity_id.length === 0) return null;
-  const suffix = entity_id.toUpperCase().replace(/[^A-Z0-9_]/g, "_");
-  if (!/^[A-Z_][A-Z0-9_]*$/.test(suffix)) return null;
-  return suffix;
+export function entity_id_to_env_suffix(entity_id: string): string[] {
+  if (typeof entity_id !== "string" || entity_id.length === 0) return [];
+  const upper = entity_id.toUpperCase();
+  // Explicit form: non-alphanumerics become underscores.
+  const underscore = upper.replace(/[^A-Z0-9_]/g, "_");
+  // Compact form: hyphens are dropped entirely; other non-alphanumerics still
+  // become underscores (a dot is still invalid as-is, underscore is the safe
+  // fallback for anything that isn't specifically kebab).
+  const stripped = upper.replace(/-/g, "").replace(/[^A-Z0-9_]/g, "_");
+
+  const valid = /^[A-Z_][A-Z0-9_]*$/;
+  const candidates: string[] = [];
+  for (const s of [underscore, stripped]) {
+    if (valid.test(s) && !candidates.includes(s)) candidates.push(s);
+  }
+  return candidates;
 }
 
 /**
@@ -107,21 +135,22 @@ export function entity_id_to_env_suffix(entity_id: string): string | null {
  * spawned for `entity_id`.
  *
  * Lookup order:
- *   1. `OP_SERVICE_ACCOUNT_TOKEN_<ENTITY_SUFFIX>` — the entity-scoped token
- *   2. `OP_SERVICE_ACCOUNT_TOKEN`                 — platform fallback (with warning)
+ *   1. `OP_SERVICE_ACCOUNT_TOKEN_<ENTITY_SUFFIX>` for each candidate suffix,
+ *      underscore form first (see `entity_id_to_env_suffix`)
+ *   2. `OP_SERVICE_ACCOUNT_TOKEN` — platform fallback (with warning)
  *
- * Returns `null` if neither is set; the session spawns without `op` access.
+ * Returns `null` if nothing is set; the session spawns without `op` access.
  *
  * The fallback path logs a warning and adds a Sentry breadcrumb. Neither
- * surface contains the token value — only the entity id and the suffix
- * that was looked up.
+ * surface contains the token value — only the entity id and the suffixes
+ * that were tried.
  */
 export function resolve_entity_op_token(
   entity_id: string,
   env: Record<string, string | undefined> = process.env,
 ): string | null {
-  const suffix = entity_id_to_env_suffix(entity_id);
-  if (suffix) {
+  const suffixes = entity_id_to_env_suffix(entity_id);
+  for (const suffix of suffixes) {
     const scoped = env[`OP_SERVICE_ACCOUNT_TOKEN_${suffix}`];
     if (scoped) return scoped;
   }
@@ -137,7 +166,7 @@ export function resolve_entity_op_token(
         category: "pool.op-token",
         message: "entity-scoped OP token missing, fell back to platform token",
         level: "warning",
-        data: { entity_id, suffix: suffix ?? null },
+        data: { entity_id, suffixes_tried: suffixes },
       });
     } catch {
       // Never let a Sentry misconfig break session startup. The warning above


### PR DESCRIPTION
## Summary

`resolve_entity_op_token` now tolerates both env-var naming conventions in play across `~/.lobsterfarm/secrets/op-tokens.env`:

- `OP_SERVICE_ACCOUNT_TOKEN_LOBSTER_FARM` (kebab → underscore, explicit)
- `OP_SERVICE_ACCOUNT_TOKEN_LOBSTERFARM` (kebab → stripped, compact)

`entity_id_to_env_suffix` now returns an ordered, deduped list of candidate suffixes — underscore first so the explicit form wins when both exist. For ids without hyphens (`healthydogs`, `paragonmm`), both candidates collapse to one and we do a single env lookup. The Sentry fallback breadcrumb now includes `suffixes_tried` so ops can see exactly which variants were probed.

Option A from the issue spec — no ops coordination required, no rename of existing secrets, no flag-day.

## Evidence

From `~/.lobsterfarm/logs/daemon.log` (2026-04-19):

```
[pool] WARN: no entity-scoped OP token for lobster-farm, falling back to platform token
```

The resolver normalized `lobster-farm` → `LOBSTER_FARM` and missed the actually-configured `OP_SERVICE_ACCOUNT_TOKEN_LOBSTERFARM`. After this change the stripped candidate is attempted second and resolves.

## Test plan

New + updated tests in `packages/daemon/src/__tests__/pool-op-token.test.ts`:

- [x] `lobster-farm` + only `OP_SERVICE_ACCOUNT_TOKEN_LOBSTERFARM` set → resolves stripped, no warning
- [x] `lobster-farm` + only `OP_SERVICE_ACCOUNT_TOKEN_LOBSTER_FARM` set → resolves underscore, no warning
- [x] `lobster-farm` + both set → underscore form wins (explicit preferred)
- [x] `lobster-farm` + neither set → platform fallback + warning + breadcrumb
- [x] `healthydogs` + `OP_SERVICE_ACCOUNT_TOKEN_HEALTHYDOGS` set → resolves (candidates deduped to single lookup)
- [x] Collision: `lobsterfarm` and `lobster-farm` both resolve to `LOBSTERFARM` when it's the only token present (documented behavior)
- [x] Collision inverse: `LOBSTER_FARM` token serves only `lobster-farm`; `lobsterfarm` falls back
- [x] Breadcrumb `data.suffixes_tried` lists every candidate attempted
- [x] Multi-hyphen ids (`a-b-c` → `["A_B_C", "ABC"]`) preserved order + dedupe
- [x] Digit-leading ids still rejected (both candidates invalid → empty list)
- [x] No token values appear in any log, breadcrumb, or test assertion

### Verification

- [x] `pnpm -r test` — 1050 daemon tests passing, full monorepo green
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm lint` (biome) — clean

### Sanity check (post-merge, deploy-time)

- [ ] Restart daemon, confirm `[pool] WARN: no entity-scoped OP token for lobster-farm` no longer appears in `~/.lobsterfarm/logs/daemon.log`

## Known collision

`lobsterfarm` and `lobster-farm` both include `LOBSTERFARM` in their candidate list. We don't have that entity-id collision today — if it ever arises, the fix is per-entity scoped tokens with explicit underscore names (future Option B/C territory, not this PR).

Closes #13