### PR TITLE
fix(cli): lf update refuses to run off main or with dirty tree

### DIFF
--- a/packages/cli/src/__tests__/update.test.ts
+++ b/packages/cli/src/__tests__/update.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for `lf update` preconditions.
+ *
+ * The helpers shell out to git via `execFileSync`. We mock it at the
+ * `node:child_process` module level and drive per-test behavior with a
+ * queue of responses (one per expected git invocation).
+ *
+ * Each response is either a string (resolves as stdout) or an Error
+ * (simulates a git failure — the mock re-throws it with stderr attached).
+ */
+
+type GitResponse = string | { error: string; stderr?: string };
+
+// Queue of responses, consumed in order by the mocked execFileSync.
+let responses: GitResponse[] = [];
+// Calls captured for assertions (args only — cwd/options are uninteresting).
+let calls: string[][] = [];
+
+vi.mock("node:child_process", () => ({
+  execFileSync: (_cmd: string, args: string[]) => {
+    calls.push(args);
+    const next = responses.shift();
+    if (next === undefined) {
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    }
+    if (typeof next === "string") return next;
+    const err: Error & { stderr?: string; status?: number } = new Error(next.error);
+    err.stderr = next.stderr ?? next.error;
+    err.status = 128;
+    throw err;
+  },
+}));
+
+beforeEach(() => {
+  responses = [];
+  calls = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("check_on_main", () => {
+  it("returns ok when HEAD is main", async () => {
+    responses = ["main\n"];
+    const { check_on_main } = await import("../commands/update.js");
+
+    const result = check_on_main("/repo");
+
+    expect(result.ok).toBe(true);
+    expect(calls[0]).toEqual(["symbolic-ref", "--short", "HEAD"]);
+  });
+
+  it("refuses on a feature branch with the exact switch command", async () => {
+    responses = ["feat/295-discord-roles\n"];
+    const { check_on_main, EXIT_BRANCH_NOT_MAIN } = await import("../commands/update.js");
+
+    const result = check_on_main("/repo");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.exit_code).toBe(EXIT_BRANCH_NOT_MAIN);
+    expect(result.message).toContain("feat/295-discord-roles");
+    expect(result.message).toContain("git checkout main && lf update");
+  });
+
+  it("reports detached HEAD cleanly", async () => {
+    responses = [{ error: "symbolic-ref failed", stderr: "fatal: ref HEAD is not a symbolic ref" }];
+    const { check_on_main, EXIT_BRANCH_NOT_MAIN } = await import("../commands/update.js");
+
+    const result = check_on_main("/repo");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.exit_code).toBe(EXIT_BRANCH_NOT_MAIN);
+    expect(result.message).toContain("HEAD (detached)");
+    expect(result.message).toContain("git checkout main && lf update");
+  });
+
+  it("surfaces git's stderr when not a git repo", async () => {
+    responses = [
+      {
+        error: "git failed",
+        stderr: "fatal: not a git repository (or any of the parent directories): .git",
+      },
+    ];
+    const { check_on_main } = await import("../commands/update.js");
+
+    const result = check_on_main("/tmp/not-a-repo");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("not a git repository");
+  });
+});
+
+describe("check_working_tree_clean", () => {
+  it("returns ok on an empty porcelain output", async () => {
+    responses = [""];
+    const { check_working_tree_clean } = await import("../commands/update.js");
+
+    const result = check_working_tree_clean("/repo");
+
+    expect(result.ok).toBe(true);
+    expect(calls[0]).toEqual(["status", "--porcelain"]);
+  });
+
+  it("refuses when tracked files are modified and lists the paths", async () => {
+    responses = [" M packages/foo/bar.ts\nM  packages/baz/qux.ts\n"];
+    const { check_working_tree_clean, EXIT_TREE_DIRTY } = await import("../commands/update.js");
+
+    const result = check_working_tree_clean("/repo");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.exit_code).toBe(EXIT_TREE_DIRTY);
+    expect(result.message).toContain("packages/foo/bar.ts");
+    expect(result.message).toContain("packages/baz/qux.ts");
+    expect(result.message).toContain("Commit or stash first");
+  });
+
+  it("allows untracked-only output", async () => {
+    responses = ["?? worktrees/something/\n?? scratch.txt\n"];
+    const { check_working_tree_clean } = await import("../commands/update.js");
+
+    const result = check_working_tree_clean("/repo");
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("truncates long dirty lists after 5 entries", async () => {
+    const lines = Array.from({ length: 8 }, (_, i) => ` M file-${String(i)}.ts`).join("\n");
+    responses = [lines];
+    const { check_working_tree_clean } = await import("../commands/update.js");
+
+    const result = check_working_tree_clean("/repo");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("file-0.ts");
+    expect(result.message).toContain("file-4.ts");
+    expect(result.message).not.toContain("file-5.ts");
+    expect(result.message).toContain("+3 more");
+  });
+
+  it("surfaces git errors when status itself fails", async () => {
+    responses = [{ error: "git failed", stderr: "fatal: not a git repository" }];
+    const { check_working_tree_clean, EXIT_GIT_ERROR } = await import("../commands/update.js");
+
+    const result = check_working_tree_clean("/repo");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.exit_code).toBe(EXIT_GIT_ERROR);
+    expect(result.message).toContain("not a git repository");
+  });
+});
+
+describe("precondition ordering", () => {
+  it("reports the branch error first when both preconditions would fail", async () => {
+    // Simulate the "wrong branch AND dirty tree" case: both checks run
+    // independently and each calls git once. We queue both responses, then
+    // assert the branch failure is what the caller would see first.
+    responses = ["some-feature\n", " M packages/foo/bar.ts\n"];
+    const { check_on_main, check_working_tree_clean } = await import("../commands/update.js");
+
+    const branch_result = check_on_main("/repo");
+    const tree_result = check_working_tree_clean("/repo");
+
+    expect(branch_result.ok).toBe(false);
+    expect(tree_result.ok).toBe(false);
+    if (branch_result.ok || tree_result.ok) return;
+    // The branch error is the actionable one — it names the exact fix.
+    expect(branch_result.message).toContain("some-feature");
+    expect(branch_result.message).toContain("git checkout main && lf update");
+  });
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -39,13 +39,125 @@ function resolve_repo_root(): string {
   }
 }
 
-/** Run a git command in the repo directory, returning stdout. */
+/** Run a git command in the repo directory, returning trimmed stdout. */
 function git(repo_dir: string, args: string[]): string {
+  return git_raw(repo_dir, args).trim();
+}
+
+/** Run a git command, returning stdout exactly as emitted (no trimming). */
+function git_raw(repo_dir: string, args: string[]): string {
   return execFileSync("git", args, {
     cwd: repo_dir,
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
-  }).trim();
+  });
+}
+
+/**
+ * Exit codes for precondition failures. Distinct codes make it easier for
+ * callers (shell scripts, CI) to react to specific failure modes.
+ */
+export const EXIT_BRANCH_NOT_MAIN = 1;
+export const EXIT_TREE_DIRTY = 2;
+export const EXIT_GIT_ERROR = 3;
+
+export type PreconditionResult = { ok: true } | { ok: false; exit_code: number; message: string };
+
+/**
+ * Verify HEAD is on `main`.
+ *
+ * Uses `git symbolic-ref --short HEAD` — fails cleanly when HEAD is detached
+ * (no symbolic ref), so we can report that as its own case rather than
+ * letting a raw git error bubble up.
+ */
+export function check_on_main(repo_dir: string): PreconditionResult {
+  let branch: string;
+  try {
+    branch = git(repo_dir, ["symbolic-ref", "--short", "HEAD"]);
+  } catch (err) {
+    // Most common cause: detached HEAD (no symbolic ref). Include git's
+    // stderr so repo-level errors (not a git repo, etc.) are still visible.
+    const stderr = extract_stderr(err);
+    const detail = stderr ? ` (${stderr})` : "";
+    return {
+      ok: false,
+      exit_code: EXIT_BRANCH_NOT_MAIN,
+      message: `lf update must be run from main. You are on HEAD (detached)${detail}.\nSwitch to main: git checkout main && lf update`,
+    };
+  }
+
+  if (branch !== "main") {
+    return {
+      ok: false,
+      exit_code: EXIT_BRANCH_NOT_MAIN,
+      message: `lf update must be run from main. You are on '${branch}'.\nSwitch to main: git checkout main && lf update`,
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Verify the working tree has no uncommitted changes to tracked files.
+ *
+ * Untracked files (`??`) are ignored — worktrees, build artifacts, and other
+ * local-only paths shouldn't block an update. Any other status code (modified,
+ * added, deleted, renamed, copied, unmerged) blocks with the offending paths.
+ */
+export function check_working_tree_clean(repo_dir: string): PreconditionResult {
+  let output: string;
+  try {
+    // Use raw (untrimmed) output — porcelain v1 starts each line with a
+    // two-char status code, and the leading space of `_M path` must survive.
+    output = git_raw(repo_dir, ["status", "--porcelain"]);
+  } catch (err) {
+    const stderr = extract_stderr(err);
+    return {
+      ok: false,
+      exit_code: EXIT_GIT_ERROR,
+      message: `Failed to check working tree status.${stderr ? ` ${stderr}` : ""}`,
+    };
+  }
+
+  const dirty_paths = parse_dirty_paths(output);
+  if (dirty_paths.length === 0) return { ok: true };
+
+  const preview = dirty_paths.slice(0, 5).join(", ");
+  const suffix = dirty_paths.length > 5 ? ` (+${dirty_paths.length - 5} more)` : "";
+  return {
+    ok: false,
+    exit_code: EXIT_TREE_DIRTY,
+    message: `lf update requires a clean working tree. You have uncommitted changes: ${preview}${suffix}.\nCommit or stash first, then re-run: lf update`,
+  };
+}
+
+/**
+ * Parse `git status --porcelain` output, returning paths that have
+ * tracked-file changes. Untracked entries (status `??`) are excluded.
+ *
+ * Porcelain v1 format: `XY <path>` where X/Y are status codes. A line with
+ * `??` is untracked; anything else counts as a change to a tracked file.
+ */
+function parse_dirty_paths(porcelain: string): string[] {
+  const paths: string[] = [];
+  for (const line of porcelain.split("\n")) {
+    if (line.length < 3) continue;
+    const status = line.slice(0, 2);
+    if (status === "??") continue;
+    // Rename/copy entries look like `R  old -> new`; keep the full payload so
+    // the user sees exactly what git sees.
+    paths.push(line.slice(3).trim());
+  }
+  return paths;
+}
+
+/** Pull stderr off a child_process error, trimming trailing newlines. */
+function extract_stderr(err: unknown): string {
+  if (err && typeof err === "object" && "stderr" in err) {
+    const stderr = (err as { stderr?: Buffer | string }).stderr;
+    if (stderr) return stderr.toString().trim();
+  }
+  return "";
 }
 
 export const update_command = new Command("update")
@@ -57,6 +169,16 @@ export const update_command = new Command("update")
     } catch (err) {
       console.error(err instanceof Error ? err.message : "Failed to resolve repo root.");
       process.exit(1);
+    }
+
+    // Preconditions: must be on main with a clean tree. Branch check runs
+    // first — if both fail, the branch error is the actionable one.
+    for (const check of [check_on_main, check_working_tree_clean]) {
+      const result = check(repo_dir);
+      if (!result.ok) {
+        console.error(result.message);
+        process.exit(result.exit_code);
+      }
     }
 
     console.log("Checking for updates...");


### PR DESCRIPTION
## Summary

`lf update` previously ran `git pull origin main` against whatever branch was checked out, which broke with a divergent-branches error on feature branches and risked silent bad merges. This adds two preconditions that refuse the update cleanly and tell the user the exact fix.

- `check_on_main` — uses `git symbolic-ref --short HEAD` so detached-HEAD reports cleanly instead of as a raw git error.
- `check_working_tree_clean` — parses `git status --porcelain`, ignores untracked entries (`??`), blocks on any other status with up to 5 offending paths shown.
- When both checks would fail, the branch error wins (it's the actionable one).
- Distinct exit codes: `1` branch wrong, `2` tree dirty, `3` git itself failed.

## Sample error output

Wrong branch:
```
lf update must be run from main. You are on 'feat/295-discord-roles'.
Switch to main: git checkout main && lf update
```

Dirty tree on main:
```
lf update requires a clean working tree. You have uncommitted changes: README.md.
Commit or stash first, then re-run: lf update
```

Detached HEAD:
```
lf update must be run from main. You are on HEAD (detached) (fatal: ref HEAD is not a symbolic ref).
Switch to main: git checkout main && lf update
```

## Test plan

New file: `packages/cli/src/__tests__/update.test.ts`. Ten tests covering:

- [x] Happy path — `check_on_main` returns ok when HEAD is `main`
- [x] Wrong branch — exit code 1, error names the branch and includes `git checkout main && lf update`
- [x] Detached HEAD — reported as `HEAD (detached)` with git's stderr inline
- [x] Not a git repo — surfaces git's stderr cleanly
- [x] Clean tree — `check_working_tree_clean` returns ok on empty porcelain
- [x] Dirty tracked files — exit code 2, lists the paths, suggests commit/stash
- [x] Untracked-only (`??`) — not blocked (per spec)
- [x] Long dirty list — truncated to 5 with `(+N more)` suffix
- [x] Status itself fails — exit code 3, stderr surfaced
- [x] Wrong branch + dirty tree — branch error wins

Also verified manually in a throwaway clone:

- [x] main + clean → proceeds through fetch
- [x] main + dirty tracked file → refuses with exit 2
- [x] main + untracked-only file → proceeds
- [x] feature branch + dirty tree → refuses with exit 1 (branch error)

`pnpm test`, `pnpm typecheck`, and `pnpm lint` all green.

Closes #11