### PR TITLE
fix(env): re-run tmux depropagate after first session spawn

### DIFF
--- a/packages/daemon/src/__tests__/env.test.ts
+++ b/packages/daemon/src/__tests__/env.test.ts
@@ -329,6 +329,61 @@ describe("propagate_tmux_env", () => {
 
     log_spy.mockRestore();
   });
+
+  it("scrubs legacy vars on the second call once tmux becomes live (issue #18)", () => {
+    // Models the fresh-boot timing bug fixed by issue #18. At daemon startup
+    // the tmux server does not yet exist, so the FIRST propagate_tmux_env
+    // call's remover silently no-ops. Later, `tmux new-session` spawned by
+    // pool bot resume creates the server, which inherits the daemon's env
+    // (including the bare OP_SERVICE_ACCOUNT_TOKEN aliased from env.sh). A
+    // SECOND propagate_tmux_env call, issued after the server is live, must
+    // successfully reach it and remove the legacy var.
+    //
+    // The second call is wired in packages/daemon/src/index.ts right after
+    // `await pool.resume_parked_bots()`. This test exercises the invariant
+    // that propagate_tmux_env is safe to call twice and that the second
+    // call is the one that actually scrubs.
+    let tmux_alive = false;
+    const removed: string[] = [];
+    const set_calls: Array<[string, string]> = [];
+
+    const setter = (key: string, value: string) => {
+      if (!tmux_alive) return false;
+      set_calls.push([key, value]);
+      return true;
+    };
+    const remover = (key: string) => {
+      if (!tmux_alive) return false; // server not running → no-op
+      removed.push(key);
+      return true;
+    };
+
+    // Token value is an opaque placeholder — the test only inspects keys,
+    // never values. Never compare against a raw token here.
+    const env = {
+      PATH: "/usr/bin",
+      HOME: "/Users/test",
+      OP_SERVICE_ACCOUNT_TOKEN: "platform-token-placeholder",
+    };
+
+    // First call: tmux server not running. Everything fails silently.
+    propagate_tmux_env(env, setter, remover);
+    expect(removed).toEqual([]);
+    expect(set_calls).toEqual([]);
+
+    // Simulate the first tmux new-session creating the server (e.g. pool
+    // bot resume in resume_parked_bots).
+    tmux_alive = true;
+
+    // Second call: the fix path. Must now actually scrub the legacy var
+    // AND propagate the whitelisted vars.
+    propagate_tmux_env(env, setter, remover);
+    expect(removed).toContain("OP_SERVICE_ACCOUNT_TOKEN");
+    expect(removed).toEqual([...TMUX_DEPROPAGATE_VARS]);
+    expect(set_calls.map(([k]) => k)).toEqual(["PATH", "HOME"]);
+    // Belt-and-suspenders: the token is NOT in the propagate set.
+    expect(set_calls.map(([k]) => k)).not.toContain("OP_SERVICE_ACCOUNT_TOKEN");
+  });
 });
 
 describe("resolve_binary", () => {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -217,6 +217,20 @@ async function main(): Promise<void> {
     await pool.resume_parked_bots();
   }
 
+  // Re-run tmux env propagation AFTER the initial pool resumes have spawned
+  // their tmux sessions. On a fresh daemon boot the first `propagate_tmux_env`
+  // call above runs before any tmux server exists, so the depropagate loop
+  // no-ops (the remover silently fails against a missing server). The first
+  // `tmux new-session` inside resume_parked_bots creates the server, which
+  // inherits the daemon's env — planting OP_SERVICE_ACCOUNT_TOKEN into the
+  // tmux global. Running propagate_tmux_env a second time here targets the
+  // now-live server and actually scrubs the legacy vars. See issue #18.
+  //
+  // Idempotent: the propagate half is a straight `tmux set-environment`
+  // (same keys, same values), and the depropagate half swallows unknown-var
+  // errors. Safe regardless of whether the first call succeeded.
+  propagate_tmux_env();
+
   // Initialize Commander (persistent Claude Code session with Discord channel)
   const commander = new CommanderProcess(config);
   if (await commander.has_token()) {


### PR DESCRIPTION
## Summary

Fixes the fresh-boot timing bug where `OP_SERVICE_ACCOUNT_TOKEN` ends up in the tmux global env despite PR #16's depropagate logic.

Root cause: `propagate_tmux_env()` was called once at daemon startup, before any tmux server existed. The depropagate loop's remover (`tmux set-environment -g -r ...`) silently no-ops against a missing server. The first `tmux new-session` spawned by `resume_parked_bots()` then creates the server, which inherits the daemon process env — planting the platform token in the tmux global and leaving it there.

## Option chosen — A (one re-run after pool resume)

Went with Hunter's preferred Option A: a single additional `propagate_tmux_env()` call in `packages/daemon/src/index.ts` right after `await pool.resume_parked_bots()`. By that point the tmux server is live (assuming there are resume candidates — the common case on `lf restart`), so the remover actually reaches it and the legacy var gets scrubbed.

Rejected Option B (per-spawn-site call in `pool.ts`) because:
- Three spawn sites to keep in sync, plus any future spawn path we add
- `propagate_tmux_env` is already designed to be idempotent, so a single well-placed second call is equivalent in outcome
- The verified bug is the hot-restart pattern, which always goes through `resume_parked_bots()` first
- Acceptance criterion #1 is scoped to "after a fresh `lf restart`" — Option A covers that cleanly

Known limitation: on a truly fresh install with zero resume candidates, the second call still runs before tmux is live (it's a no-op), and the first user-triggered `assign()` would leak the token until the next restart. This matches the existing behavior on main (no regression), and the next restart cleanly scrubs it. Worth a follow-up if someone reports it in practice, but out of scope for #18.

## Expected log on a clean boot (with resume candidates)

```
[env] tmux global cleanup: depropagated 1 legacy var(s): OP_SERVICE_ACCOUNT_TOKEN
[env] tmux server not running, will inherit daemon env
...
[pool] Proactively resuming N bot(s) that were assigned before shutdown
...
[env] tmux global cleanup: depropagated 1 legacy var(s): OP_SERVICE_ACCOUNT_TOKEN
[env] Propagated environment to tmux server
```

Post-boot sanity check:
```
$ tmux show-environment -g | grep "^OP_SERVICE_ACCOUNT_TOKEN="
(empty)
```

## Test

New test in `packages/daemon/src/__tests__/env.test.ts`: **"scrubs legacy vars on the second call once tmux becomes live (issue #18)"**. Uses a stateful `tmux_alive` flag that flips between two `propagate_tmux_env` invocations, asserts the first call removes nothing and sets nothing, and the second call scrubs `OP_SERVICE_ACCOUNT_TOKEN` + propagates the whitelist. Reuses the existing module-top `ORIGINAL_ENV` + `afterEach` env-hygiene pattern.

- env.test.ts: 24 -> 25 tests
- Daemon suite: 1058 tests, all passing
- Monorepo: full `pnpm test` green
- `pnpm typecheck` clean
- `pnpm lint` clean

## Test plan

- [ ] Reviewer confirms Option A vs B tradeoff is acceptable
- [ ] On next `lf restart`, confirm `tmux show-environment -g | grep "^OP_SERVICE_ACCOUNT_TOKEN="` returns empty
- [ ] Confirm no new warnings in daemon log at boot

Closes #18

Generated with Claude Code