### PR TITLE
fix(discord): guard send-family against empty channel_id + fix shutdown caller

### DIFF
--- a/packages/daemon/src/__tests__/discord-send-guard.test.ts
+++ b/packages/daemon/src/__tests__/discord-send-guard.test.ts
@@ -176,6 +176,22 @@ describe("send_status_embed() — empty channel_id guard (#319)", () => {
     expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
     expect(sentry.addBreadcrumb).toHaveBeenCalled();
   });
+
+  it("early-returns on undefined channel_id", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    await bot.send_status_embed(undefined as unknown as string, "planner");
+
+    expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "send_status_embed() called with empty channel_id",
+      }),
+    );
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
 });
 
 describe("send_embed() — empty channel_id guard (#319)", () => {
@@ -186,6 +202,24 @@ describe("send_embed() — empty channel_id guard (#319)", () => {
 
     const embed = new EmbedBuilder().setDescription("test");
     const result = await bot.send_embed("", embed);
+
+    expect(result).toBeNull();
+    expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "send_embed() called with empty channel_id",
+      }),
+    );
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("returns null and breadcrumbs on undefined channel_id", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    const embed = new EmbedBuilder().setDescription("test");
+    const result = await bot.send_embed(undefined as unknown as string, embed);
 
     expect(result).toBeNull();
     expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
@@ -215,6 +249,23 @@ describe("send_to_thread() — empty thread_id guard (#319)", () => {
     );
     expect(sentry.captureException).not.toHaveBeenCalled();
   });
+
+  it("early-returns on undefined thread_id", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    await bot.send_to_thread(undefined as unknown as string, "hello");
+
+    expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "send_to_thread() called with empty channel_id",
+        data: expect.objectContaining({ content_preview: "hello" }),
+      }),
+    );
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
 });
 
 describe("send_as_agent() — empty channel_id guard (#319)", () => {
@@ -226,6 +277,23 @@ describe("send_as_agent() — empty channel_id guard (#319)", () => {
     // If the guard didn't fire, send_as_agent would either hit the webhook
     // path or fall through to send() — both routes ultimately call fetch.
     await bot.send_as_agent("", "hello", "planner");
+
+    expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "send_as_agent() called with empty channel_id",
+        data: expect.objectContaining({ content_preview: "hello" }),
+      }),
+    );
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("early-returns on undefined channel_id", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    await bot.send_as_agent(undefined as unknown as string, "hello", "planner");
 
     expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
     expect(sentry.addBreadcrumb).toHaveBeenCalledWith(

--- a/packages/daemon/src/__tests__/discord-send-guard.test.ts
+++ b/packages/daemon/src/__tests__/discord-send-guard.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for the empty-channel-id defensive guard on the send-family methods of
+ * DiscordBot (#319).
+ *
+ * Background: during shutdown drain, `index.ts` was calling `discord.send("",
+ * ...)` which threw inside `client.channels.fetch("")` and produced noisy 404
+ * Sentry events on every clean shutdown. The fix is twofold:
+ *   1) Each send-family method early-returns on empty/whitespace channel ids
+ *      and emits a Sentry breadcrumb (NOT a captureException — we don't want
+ *      this paging) so the offending caller is attributable.
+ *   2) The shutdown caller in `index.ts` now resolves a real channel via
+ *      `find_system_status_channel()` before calling send().
+ *
+ * These tests cover (1) — the guard. The caller fix in `index.ts` is verified
+ * indirectly: the structural change (no more empty-string ternary) is plain
+ * to read in the diff and there is no behavioral regression because the
+ * previous code never delivered the message anyway.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { EmbedBuilder } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──
+
+vi.mock("../sentry.js", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+vi.mock("discord.js", async () => {
+  const actual = await vi.importActual<typeof import("discord.js")>("discord.js");
+  return {
+    ...actual,
+    Client: vi.fn().mockImplementation(() => ({
+      on: vi.fn(),
+      once: vi.fn(),
+      login: vi.fn(),
+      destroy: vi.fn(),
+      user: null,
+      channels: { fetch: vi.fn() },
+      guilds: { fetch: vi.fn() },
+      application: null,
+    })),
+  };
+});
+
+import { DiscordBot } from "../discord.js";
+import { EntityRegistry } from "../registry.js";
+import * as sentry from "../sentry.js";
+
+// ── Test helpers ──
+
+let temp_dir: string;
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
+  });
+}
+
+/**
+ * Test subclass that flips `connected = true` so the guard runs ahead of the
+ * offline-mode short-circuit, and exposes the underlying discord.js channels
+ * mock for assertions.
+ */
+class TestDiscordBot extends DiscordBot {
+  constructor(config: LobsterFarmConfig, registry: EntityRegistry) {
+    super(config, registry);
+    (this as unknown as { connected: boolean }).connected = true;
+  }
+
+  get channels_fetch_mock() {
+    return (this as unknown as { client: { channels: { fetch: ReturnType<typeof vi.fn> } } }).client
+      .channels.fetch;
+  }
+}
+
+beforeEach(async () => {
+  temp_dir = await mkdtemp(join(tmpdir(), "lf-discord-send-guard-test-"));
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await rm(temp_dir, { recursive: true, force: true });
+});
+
+// ── Tests ──
+
+describe("send() — empty channel_id guard (#319)", () => {
+  for (const [label, value] of [
+    ["empty string", ""],
+    ["whitespace only", "   "],
+    ["undefined", undefined as unknown as string],
+  ] as const) {
+    it(`early-returns and breadcrumbs for ${label}`, async () => {
+      const config = make_config();
+      const registry = new EntityRegistry(config);
+      const bot = new TestDiscordBot(config, registry);
+
+      await bot.send(value, "hello");
+
+      expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
+      expect(sentry.addBreadcrumb).toHaveBeenCalledTimes(1);
+      expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: "discord",
+          level: "warning",
+          message: "send() called with empty channel_id",
+          data: expect.objectContaining({ content_preview: "hello" }),
+        }),
+      );
+      expect(sentry.captureException).not.toHaveBeenCalled();
+    });
+  }
+
+  it("truncates content_preview to 80 chars", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    const long_content = "x".repeat(200);
+    await bot.send("", long_content);
+
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ content_preview: "x".repeat(80) }),
+      }),
+    );
+  });
+
+  it("permits valid channel_id through to fetch (sanity check)", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    // Have fetch return a non-text channel so we exit cleanly without sending.
+    bot.channels_fetch_mock.mockResolvedValue(null);
+
+    await bot.send("123456789012345678", "hello");
+
+    expect(bot.channels_fetch_mock).toHaveBeenCalledWith("123456789012345678");
+    expect(sentry.addBreadcrumb).not.toHaveBeenCalled();
+  });
+});
+
+describe("send_status_embed() — empty channel_id guard (#319)", () => {
+  it("early-returns on empty channel_id without fetching", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    await bot.send_status_embed("", "planner");
+
+    expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "send_status_embed() called with empty channel_id",
+      }),
+    );
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("early-returns on whitespace-only channel_id", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    await bot.send_status_embed("   ", "planner");
+
+    expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalled();
+  });
+});
+
+describe("send_embed() — empty channel_id guard (#319)", () => {
+  it("returns null and breadcrumbs without fetching", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    const embed = new EmbedBuilder().setDescription("test");
+    const result = await bot.send_embed("", embed);
+
+    expect(result).toBeNull();
+    expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "send_embed() called with empty channel_id",
+      }),
+    );
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+});
+
+describe("send_to_thread() — empty thread_id guard (#319)", () => {
+  it("early-returns on empty thread_id without fetching", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    await bot.send_to_thread("", "hello");
+
+    expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "send_to_thread() called with empty channel_id",
+        data: expect.objectContaining({ content_preview: "hello" }),
+      }),
+    );
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+});
+
+describe("send_as_agent() — empty channel_id guard (#319)", () => {
+  it("early-returns on empty channel_id without delegating", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    // If the guard didn't fire, send_as_agent would either hit the webhook
+    // path or fall through to send() — both routes ultimately call fetch.
+    await bot.send_as_agent("", "hello", "planner");
+
+    expect(bot.channels_fetch_mock).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "send_as_agent() called with empty channel_id",
+        data: expect.objectContaining({ content_preview: "hello" }),
+      }),
+    );
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("still emits exactly one breadcrumb (no double-emit via inner send())", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    await bot.send_as_agent("", "hello", "planner");
+
+    // Outer guard short-circuits — inner send() never runs, so we get one
+    // breadcrumb (from send_as_agent), not two.
+    expect(sentry.addBreadcrumb).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("send-family — captureException is never called on empty id (#319)", () => {
+  it("none of the guard paths produce a Sentry exception event", async () => {
+    const config = make_config();
+    const registry = new EntityRegistry(config);
+    const bot = new TestDiscordBot(config, registry);
+
+    const embed = new EmbedBuilder().setDescription("x");
+    await bot.send("", "x");
+    await bot.send_status_embed("", "planner");
+    await bot.send_embed("", embed);
+    await bot.send_to_thread("", "x");
+    await bot.send_as_agent("", "x", "planner");
+
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    // 5 breadcrumbs — one per call.
+    expect(sentry.addBreadcrumb).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -704,8 +704,32 @@ export class DiscordBot extends EventEmitter {
     return this.command_center_channel_id;
   }
 
+  /**
+   * Defensive guard: returns true and logs if `channel_id` is empty/whitespace.
+   * Caller should early-return on `true`. Captures a Sentry breadcrumb (not an
+   * exception event) so we get caller attribution without paging — a real bug
+   * upstream of the call should be fixed at the source, this is only the net.
+   */
+  private assert_empty_channel_id(
+    method_name: string,
+    channel_id: string | undefined | null,
+    content?: string,
+  ): boolean {
+    if (channel_id?.trim()) return false;
+    const err = new Error(`${method_name}() called with empty channel_id`);
+    console.warn(`[discord] ${err.message}`, err.stack);
+    sentry.addBreadcrumb({
+      category: "discord",
+      level: "warning",
+      message: err.message,
+      data: { content_preview: content?.slice(0, 80) },
+    });
+    return true;
+  }
+
   /** Send a plain message to a channel (from the bot itself). */
   async send(channel_id: string, content: string): Promise<void> {
+    if (this.assert_empty_channel_id("send", channel_id, content)) return;
     if (!this.connected) {
       console.log(`[discord:offline] Would send to ${channel_id}: ${content}`);
       return;
@@ -1060,6 +1084,7 @@ export class DiscordBot extends EventEmitter {
    * Stores the message ID so we can edit it when the agent finishes.
    */
   async send_status_embed(channel_id: string, archetype: ArchetypeRole | "system"): Promise<void> {
+    if (this.assert_empty_channel_id("send_status_embed", channel_id)) return;
     if (!this.connected) return;
 
     // Don't stack embeds — finalize any existing one first
@@ -1188,6 +1213,7 @@ export class DiscordBot extends EventEmitter {
     content: string,
     archetype: ArchetypeRole | "system",
   ): Promise<void> {
+    if (this.assert_empty_channel_id("send_as_agent", channel_id, content)) return;
     if (!this.connected) {
       console.log(`[discord:offline] [${archetype}] ${content}`);
       return;
@@ -1252,6 +1278,7 @@ export class DiscordBot extends EventEmitter {
 
   /** Send a Discord embed to a channel. Returns the message ID, or null on failure. */
   async send_embed(channel_id: string, embed: EmbedBuilder): Promise<string | null> {
+    if (this.assert_empty_channel_id("send_embed", channel_id)) return null;
     if (!this.connected) {
       console.log(`[discord:offline] Would send embed to ${channel_id}`);
       return null;
@@ -1306,6 +1333,7 @@ export class DiscordBot extends EventEmitter {
 
   /** Post a text message to a thread. */
   async send_to_thread(thread_id: string, content: string): Promise<void> {
+    if (this.assert_empty_channel_id("send_to_thread", thread_id, content)) return;
     if (!this.connected) {
       console.log(`[discord:offline] Would send to thread ${thread_id}: ${content}`);
       return;

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -705,12 +705,13 @@ export class DiscordBot extends EventEmitter {
   }
 
   /**
-   * Defensive guard: returns true and logs if `channel_id` is empty/whitespace.
-   * Caller should early-return on `true`. Captures a Sentry breadcrumb (not an
-   * exception event) so we get caller attribution without paging — a real bug
-   * upstream of the call should be fixed at the source, this is only the net.
+   * Defensive guard: returns true (and logs) when `channel_id` is empty,
+   * whitespace-only, undefined, or null. Caller should early-return on `true`.
+   * Emits a Sentry breadcrumb (not an exception event) so we get caller
+   * attribution without paging — a real bug upstream of the call should be
+   * fixed at the source, this is only the net.
    */
-  private assert_empty_channel_id(
+  private is_empty_channel_id(
     method_name: string,
     channel_id: string | undefined | null,
     content?: string,
@@ -729,7 +730,7 @@ export class DiscordBot extends EventEmitter {
 
   /** Send a plain message to a channel (from the bot itself). */
   async send(channel_id: string, content: string): Promise<void> {
-    if (this.assert_empty_channel_id("send", channel_id, content)) return;
+    if (this.is_empty_channel_id("send", channel_id, content)) return;
     if (!this.connected) {
       console.log(`[discord:offline] Would send to ${channel_id}: ${content}`);
       return;
@@ -1084,7 +1085,7 @@ export class DiscordBot extends EventEmitter {
    * Stores the message ID so we can edit it when the agent finishes.
    */
   async send_status_embed(channel_id: string, archetype: ArchetypeRole | "system"): Promise<void> {
-    if (this.assert_empty_channel_id("send_status_embed", channel_id)) return;
+    if (this.is_empty_channel_id("send_status_embed", channel_id)) return;
     if (!this.connected) return;
 
     // Don't stack embeds — finalize any existing one first
@@ -1213,7 +1214,7 @@ export class DiscordBot extends EventEmitter {
     content: string,
     archetype: ArchetypeRole | "system",
   ): Promise<void> {
-    if (this.assert_empty_channel_id("send_as_agent", channel_id, content)) return;
+    if (this.is_empty_channel_id("send_as_agent", channel_id, content)) return;
     if (!this.connected) {
       console.log(`[discord:offline] [${archetype}] ${content}`);
       return;
@@ -1278,7 +1279,7 @@ export class DiscordBot extends EventEmitter {
 
   /** Send a Discord embed to a channel. Returns the message ID, or null on failure. */
   async send_embed(channel_id: string, embed: EmbedBuilder): Promise<string | null> {
-    if (this.assert_empty_channel_id("send_embed", channel_id)) return null;
+    if (this.is_empty_channel_id("send_embed", channel_id)) return null;
     if (!this.connected) {
       console.log(`[discord:offline] Would send embed to ${channel_id}`);
       return null;
@@ -1333,7 +1334,7 @@ export class DiscordBot extends EventEmitter {
 
   /** Post a text message to a thread. */
   async send_to_thread(thread_id: string, content: string): Promise<void> {
-    if (this.assert_empty_channel_id("send_to_thread", thread_id, content)) return;
+    if (this.is_empty_channel_id("send_to_thread", thread_id, content)) return;
     if (!this.connected) {
       console.log(`[discord:offline] Would send to thread ${thread_id}: ${content}`);
       return;

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -383,13 +383,18 @@ async function main(): Promise<void> {
         `[shutdown] Draining — ${String(work_check.working_bots.length)} agent(s) still working: ${names}`,
       );
 
-      // Notify command center
+      // Notify #system-status (mirrors the startup notification path).
+      // Previously this passed an empty channel id from a placeholder ternary
+      // and produced a noisy 404 in the logs on every shutdown drain (#319).
       if (discord_connected) {
         try {
-          await discord.send(
-            config.discord?.server_id ? "" : "",
-            `Daemon shutting down — waiting for ${String(work_check.working_bots.length)} active agent(s) to finish: ${names}. Send another signal to force.`,
-          );
+          const status_channel = await discord.find_system_status_channel();
+          if (status_channel) {
+            await discord.send(
+              status_channel,
+              `Daemon shutting down — waiting for ${String(work_check.working_bots.length)} active agent(s) to finish: ${names}. Send another signal to force.`,
+            );
+          }
         } catch {
           /* best effort */
         }


### PR DESCRIPTION
_Migrated from `ultim88888888/lobster-farm#323` as part of the canonical-fork transition (Apr 28). Original body below, with issue refs updated._

---

## Summary

- Add a defensive guard on the send-family methods of `DiscordBot` so an empty/whitespace `channel_id` early-returns with a Sentry breadcrumb (not an exception event) instead of throwing a `404 Not Found` inside `client.channels.fetch("")`.
- Fix the offending caller in `index.ts`: the shutdown drain notification was hardcoded to `""` via a placeholder ternary (`config.discord?.server_id ? "" : ""`) and never delivered a message. It now resolves a real channel via `find_system_status_channel()`, mirroring the startup notification path directly above it.

## Why

Per `daemon.log:18097, 18257` the bug surfaced on every clean SIGTERM:

```
[shutdown] Draining — 1 agent(s) still working: planner (pool-1)
[discord] Failed to send to : DiscordAPIError[0]: 404: Not Found
```

Each occurrence produced a Sentry exception event tagged `module: discord, action: send`. That's noise — operationally meaningless, and it dilutes the `discord/send` signal we actually want to keep paging on.

## Implementation

**Guard (DRY).** A small private helper, `assert_empty_channel_id(method_name, channel_id, content?)`, lives at the top of the send-family group and returns `true` when the id is falsy / whitespace-only — at which point each caller early-returns. Six callsites guarded:

- `send()`
- `send_status_embed()`
- `send_embed()`
- `send_to_thread()`
- `send_as_agent()` — has its own webhook fetch path, so the inner `send()` guard wasn't sufficient.
- `send_to_entity()` was already covered by its existing `if (!channel_id)` map-lookup check; the delegated `send` / `send_as_agent` calls retain belt-and-suspenders coverage.

The guard emits `sentry.addBreadcrumb` with `level: "warning"`, the offending method name, and an 80-char content preview. **Deliberately not `captureException`** — that would just relocate the noise we're trying to remove.

**Caller fix.** `index.ts` shutdown handler now mirrors the startup notification path: resolve `find_system_status_channel()`, gate on a non-null result, then `send()`. As a bonus, this turns a previously-broken shutdown notification into one that actually lands in `#system-status`.

## Tests

`packages/daemon/src/__tests__/discord-send-guard.test.ts` (14 cases):

- Each of the 5 guarded methods × empty / whitespace / (where applicable) `undefined` channel id — assert no `client.channels.fetch` call, breadcrumb captured with the right method-name message, no `captureException`.
- Content-preview truncation to 80 chars.
- Sanity check: a valid id passes through to `fetch`.
- Negative assertion: across all 5 methods, `captureException` is never invoked from the guard path; exactly 5 breadcrumbs land.

## Test plan

- [x] `pnpm --filter @lobster-farm/daemon test` — 1122/1123 pass; the single failure (`session-start-hook.test.ts`) is environment-dependent (the test inherits `process.env` from the parent; the running daemon's `LF_PENDING_FILE` leaks in) and reproduces on **clean upstream/main** when the daemon has a pending file. Unrelated to this change.
- [x] `pnpm --filter @lobster-farm/daemon build` — clean.
- [x] `pnpm --filter @lobster-farm/daemon exec tsc --noEmit` — clean.
- [x] `pnpm exec biome check` on the three modified files — clean.

## Notes

- Cross-fork PR by necessity (auth gap tracked under #321 — not blocking here).
- Diff is small: 3 files, +308/-5 (most of that is the new test file).
- Branch is based directly on `upstream/main` so there's no Phase-2 / unrelated-commit pollution.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)