### PR TITLE
docs(coding-dna): document agent worktree test workarounds

### DIFF
--- a/config/claude/skills/coding-dna/SKILL.md
+++ b/config/claude/skills/coding-dna/SKILL.md
@@ -1076,6 +1076,25 @@ Loggers are configurable per-environment. In prod you want structured logs. In d
 
 ---
 
+## Running tests in agent worktrees
+
+_Temporary workarounds for the LobsterFarm monorepo. Sunset clause at the bottom of this section._
+
+When you're an agent working inside a worktree under `~/.lobsterfarm/entities/<entity>/repos/<repo>/worktrees/`, follow these three rules until further notice:
+
+1. **Prefer `pnpm --filter <package> test` over `pnpm -r test`.**
+   The recursive form runs the full daemon test suite (~1100+ tests) plus `cli` and `shared` in parallel, and has been killed with SIGKILL (exit 137) 3-for-3 times. Filtered runs of a single package complete in under 300ms and have never been killed. If you genuinely need cross-package coverage, run each filter sequentially in separate commands — never gang them up under `-r`.
+
+2. **Push commits eagerly.**
+   After every meaningful milestone (a package's tests pass, a refactor is complete, or before any heavy command), `git push -u origin <branch>`. Treat unpushed commits as work that doesn't exist yet — because in this environment, it doesn't.
+
+3. **Worktrees are not durable storage.**
+   Until issue #27 lands, the periodic cleanup sweep can remove a worktree whose branch isn't on `origin`. If your worktree disappears, your work is gone. Pushing is the only way to make it real. See also issue #28 (the SIGKILL root-cause investigation) — these workarounds exist because both are still open.
+
+**When to remove this section:** Delete it once **both** #27 and #28 are merged **and** `pnpm -r test` has been observed to no longer SIGKILL for at least one week.
+
+---
+
 ## Anti-Patterns — Things We Don't Do
 
 | Don't | Do Instead |


### PR DESCRIPTION
## Summary

Adds a new `## Running tests in agent worktrees` section to `config/claude/skills/coding-dna/SKILL.md` capturing three durable workarounds agents need to follow until #27 and #28 are resolved:

- Prefer `pnpm --filter <package> test` over `pnpm -r test` (recursive form has been SIGKILL'd 3-for-3 times)
- Push commits eagerly — unpushed commits are not durable
- Worktrees are not durable storage until #27's cleanup guardrail lands

Includes an explicit sunset clause: remove the section once #27 and #28 are both merged AND `pnpm -r test` has been observed to no longer SIGKILL for at least one week.

## Why here

The issue says "add to coding-dna or wherever build/test guidance lives." The in-repo template at `config/claude/skills/coding-dna/SKILL.md` is the source-of-truth for the personal `~/.claude/skills/coding-dna/SKILL.md` (per `docs/INDEX.md`), so editing it here is the correct PR-able location. Hunter's personal `~/.claude/CLAUDE.md` is intentionally untouched.

## Out of scope (per issue)

- Implementing #27 (in PR #30) or #28 (still investigation)
- Pre-push hooks or any enforcement code
- Test infrastructure / vitest config changes

## Test plan

- [ ] Markdown renders correctly on GitHub
- [ ] Section heading is discoverable in the rendered TOC of the SKILL file
- [ ] Cross-references to #27 and #28 link correctly

Closes #29