### PR TITLE
feat: run-tests-isolated.sh wrapper to break coalition inheritance (#36)

### DIFF
--- a/config/claude/skills/coding-dna/SKILL.md
+++ b/config/claude/skills/coding-dna/SKILL.md
@@ -1078,33 +1078,53 @@ Loggers are configurable per-environment. In prod you want structured logs. In d
 
 ## Running tests in agent worktrees
 
-_Temporary workarounds for the LobsterFarm monorepo. Sunset clause at the bottom of this section._
+_Workarounds for the macOS coalition-inheritance kill path (#28). Sunset clause at the bottom of this section._
 
-When you're an agent working inside a worktree under `~/.lobsterfarm/entities/<entity>/repos/<repo>/worktrees/`, follow these three rules until further notice:
+When you're an agent working inside a worktree under `~/.lobsterfarm/entities/<entity>/repos/<repo>/worktrees/`, the issue is this: every process spawned from your agent session inherits the daemon's macOS resource coalition (`com.lobsterfarm.daemon`, id 1153) and bills its disk writes against a shared 2 GiB / 24 h budget. Parallel vitest workers exhaust the budget quickly, and the kernel SIGKILLs the heaviest writer (exit 137). Coalition membership is set at `posix_spawn` time and is **not** changed by `setsid`, `nohup`, `sudo`, `launchctl asuser`, or `sandbox-exec` (all empirically ruled out in PRs #34 and #35).
 
-1. **Use `pnpm --filter <package> test` — it is the only reliable workaround.**
-   `pnpm -r test` runs the full daemon test suite (~1100+ tests) plus `cli` and `shared` in parallel. Inside an agent session it gets SIGKILL'd (exit 137) — not because of memory, but because every descendant of the daemon inherits a macOS resource coalition with a 2 GiB / 24h dirty-write budget, and the parallel vitest workers blow through what's left of it. Root cause analysis in #28.
+There is exactly one userspace mechanism that breaks the inheritance: dynamically bootstrapping a one-shot LaunchAgent. `launchctl` itself holds the private entitlement that lets it create a fresh coalition; processes started via `launchctl bootstrap gui/$UID <plist>` get their own coalition with a fresh 2 GiB / 24 h budget.
 
-   **There is currently no userspace wrapper that breaks this inheritance on Darwin.** Empirical testing (in PR #34) confirmed that `setsid`, `setsid -f`, `nohup`, `sudo bash`, `launchctl asuser`, and `sandbox-exec` all leave spawned processes in the daemon's coalition — coalition membership is set at `posix_spawn` time and is not affected by POSIX session/group manipulation. Earlier versions of this doc recommended `setsid pnpm -r test`; that guidance was wrong and has been removed.
+### Primary method — wrap test runs in `scripts/run-tests-isolated.sh`
 
-   **What to do:**
-   - `pnpm --filter <package> test` — the default and only safe form for in-session work. Use this.
-   - **If you genuinely need cross-package coverage**, run multiple `--filter` invocations sequentially in **separate** commands. Do not gang them up under `-r`. Example: `pnpm --filter @lobster-farm/shared test`, then `pnpm --filter @lobster-farm/cli test`, then `pnpm --filter @lobster-farm/daemon test`. Sequential `--filter` runs keep peak concurrent I/O bounded; `-r` does not.
-   - `pnpm -r test` (with or without any wrapper) — only safe outside agent sessions (your own terminal, CI). Inside an agent session it will eventually SIGKILL.
+```bash
+scripts/run-tests-isolated.sh pnpm -r test
+scripts/run-tests-isolated.sh pnpm --filter @lobster-farm/daemon test
+scripts/run-tests-isolated.sh <any command>
+```
 
-   The `maxForks: 4` cap landed in #34 reduces peak vitest I/O within a single package run, but it does not change the coalition-inheritance mechanism — the workaround above is still required.
+The wrapper:
 
-2. **Push commits eagerly.**
-   After every meaningful milestone (a package's tests pass, a refactor is complete, or before any heavy command), `git push -u origin <branch>`. Treat unpushed commits as work that doesn't exist yet — because in this environment, it doesn't.
+- generates a unique label `com.lobsterfarm.test.<unix-ns>`, writes a one-shot plist to `/tmp/<label>.plist`, and `launchctl bootstrap`s it into your user domain
+- streams stdout and stderr to your terminal in real time (via `tail -F` on the plist's `StandardOutPath`/`StandardErrorPath`)
+- writes the wrapped command's exit code to `/tmp/<label>.exitcode` and propagates it as the wrapper's own exit status
+- cleans up the launchd service and all temp files on normal exit, on Ctrl-C, and on SIGTERM (idempotent trap)
+- forwards an explicit allowlist of non-sensitive env vars only (PATH, HOME, PNPM_HOME, NODE_ENV, LANG, LC_*, TERM, TMPDIR, CI) — **not** OP_*, AWS_*, GH_TOKEN, or anything token-shaped, because the plist is world-readable on disk
 
-3. **Worktrees are durable, but kills still cost scrollback.**
-   The cleanup-sweep data-loss path is guarded (PR #30 closed #27 — the sweep refuses to remove worktrees with uncommitted, untracked, or unpushed work) and the SIGKILL root cause is identified (#28 — macOS resource coalition dirty-write accounting). The `maxForks: 4` cap from PR #34 reduces peak I/O but does not eliminate the kill risk on a heavily-loaded coalition. A worker kill still loses your tmux scrollback and any uncommitted edits in flight — pushing eagerly turns a kill from "lose progress" into "resume from origin." Keep doing it.
+To verify isolation while a run is in flight, in another shell:
 
-**When to remove this section:** Delete it once a real coalition-isolation fix lands and is observed stable for one full week. The `maxForks: 4` cap (PR #34) reduces I/O pressure but does not address the inheritance mechanism, so it does not on its own clear the workaround.
+```bash
+launchctl print pid/$(pgrep -f vitest | head -1) | grep -A1 'name = com'
+# Expected: name = com.lobsterfarm.test.<timestamp>   (not com.lobsterfarm.daemon)
+```
 
-Candidate real fixes (all out of scope for #33/#34, none implemented yet): a launchd plist that runs the daemon outside a shared coalition, a `posix_spawn`-based wrapper that explicitly creates a new coalition, detaching agent sessions into their own launchd-managed services, or periodic daemon restart to reset the 24h budget. See #28 for the open investigation.
+If your test command needs 1Password-injected secrets, run `op run --env-file <file> -- <cmd>` **inside** the wrapped command (e.g. `scripts/run-tests-isolated.sh bash -c 'op run --env-file .env.op -- pnpm test'`). Do not export secrets in the calling shell expecting the wrapper to forward them.
 
-**Cleanup ownership:** Whoever lands the real fix owns deleting this section in the same PR. Tidus may also drive the cleanup as the planner who filed #27/#28/#33.
+### Fallback — when the wrapper script isn't available
+
+If you're working in an older worktree, on a host where `scripts/run-tests-isolated.sh` doesn't exist yet, or in a context where launchd isn't available (CI, Linux), use:
+
+- **`pnpm --filter <package> test`** — runs one package's tests under the daemon's coalition. Inside an agent session this is the only safe in-session form.
+- **Sequential `--filter` invocations** when you need cross-package coverage. Run `pnpm --filter @lobster-farm/shared test`, then `pnpm --filter @lobster-farm/cli test`, then `pnpm --filter @lobster-farm/daemon test` as separate commands. Sequential `--filter` runs keep peak concurrent I/O bounded; `pnpm -r test` does not, and will SIGKILL on a heavily-loaded coalition.
+- **Bare `pnpm -r test`** — safe outside agent sessions (your own terminal, CI). Inside an agent session, only safe when wrapped by `scripts/run-tests-isolated.sh`.
+
+The `maxForks: 4` cap from PR #34 stays as belt-and-suspenders inside a single package run, regardless of which path above you use.
+
+### Other rules that still apply
+
+- **Push commits eagerly.** After every meaningful milestone, `git push -u origin <branch>`. Treat unpushed commits as work that doesn't exist yet — because in this environment, it doesn't. Even with the wrapper, network failures and human kills still happen.
+- **Worktrees are durable.** The cleanup-sweep refuses to remove worktrees with uncommitted, untracked, or unpushed work (PR #30 closed #27). A kill costs scrollback and any uncommitted edits in flight; pushing eagerly turns "lose progress" into "resume from origin."
+
+**When to remove this section:** When the daemon itself is restructured so agent sessions are no longer descendants of coalition 1153 (e.g. session-per-launchd-service for agent workers). Until then the wrapper is required for `-r` runs and recommended for everything heavier than a single small package.
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,16 @@
+# scripts/
+
+Repo-level shell utilities. One script per concern, executable, with a header comment block explaining the why.
+
+## Contents
+
+| Script | Purpose |
+|---|---|
+| `run-tests-isolated.sh` | Wrap any command in a one-shot launchd service so it runs in a fresh macOS resource coalition, breaking inheritance from the LobsterFarm daemon's coalition (id 1153). Use `scripts/run-tests-isolated.sh pnpm -r test` from agent sessions to avoid the SIGKILL kill path documented in #28. |
+
+## Conventions
+
+- All scripts use `#!/usr/bin/env bash` and `set -euo pipefail`.
+- Each script begins with a comment block that explains **why** it exists, the mechanism it uses, and any non-obvious safety or security notes (env forwarding, cleanup, etc.).
+- Scripts are committed with `+x` (`chmod +x`) so they can be invoked directly without `bash <script>`.
+- New scripts should be macOS-friendly first (the agent host is Darwin) but degrade or no-op gracefully on Linux where possible.

--- a/scripts/run-tests-isolated.sh
+++ b/scripts/run-tests-isolated.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+#
+# run-tests-isolated.sh — run an arbitrary command inside its own macOS
+# resource coalition by bootstrapping it as a one-shot launchd service.
+#
+# WHY THIS EXISTS
+# ---------------
+# On macOS (Darwin), every process belongs to a "resource coalition" — a Mach
+# kernel concept that aggregates resource accounting (notably the dirty-write
+# I/O budget, ~2 GiB per 24 h) across a process tree. Coalition membership is
+# fixed at posix_spawn() time and is *inherited* from the spawning process.
+# POSIX-level tools (setsid, nohup, sandbox-exec, sudo, launchctl asuser) do
+# NOT change coalition membership — confirmed empirically in PRs #34 and #35.
+#
+# The LobsterFarm daemon runs in coalition `com.lobsterfarm.daemon` (id 1153
+# on the current host). Every agent session, and every process those sessions
+# spawn (including parallel vitest workers), inherits coalition 1153 and bills
+# its disk writes against the same shared 2 GiB / 24 h budget. When the budget
+# is exhausted, the kernel sends SIGKILL to the heaviest writer — usually a
+# vitest worker. The agent loses scrollback and any unpushed work.
+#
+# The only userspace mechanism that creates a fresh coalition on a SIP-enabled
+# host is `launchctl bootstrap`: launchd itself holds the private entitlement
+# `com.apple.private.coalition-policy` and can call coalition_create() on our
+# behalf. A process started this way runs in a brand-new coalition named after
+# the plist's Label, with its own fresh 2 GiB / 24 h write budget. Children
+# spawned by that process inherit the new coalition, not 1153.
+#
+# This script wraps an arbitrary command in a one-shot LaunchAgent so the
+# command (and all of its descendants — pnpm, node, vitest workers, …) runs
+# in a coalition isolated from the daemon. See investigation report at
+# docs/investigation-35-coalition-isolation-notes.md on branch
+# `investigation/35-coalition-isolation`, and issues #28, #35, #36.
+#
+# USAGE
+# -----
+#   scripts/run-tests-isolated.sh <command> [args...]
+#
+# Examples:
+#   scripts/run-tests-isolated.sh pnpm -r test
+#   scripts/run-tests-isolated.sh pnpm --filter @lobster-farm/daemon test
+#   scripts/run-tests-isolated.sh bash -c 'echo hi && ls'
+#
+# VERIFICATION
+# ------------
+# While the wrapped command runs, in another shell:
+#   pgrep -f vitest                    # find a worker pid
+#   launchctl print pid/<pid> | grep -i coalition
+# The `name = ...` line should show `com.lobsterfarm.test.<timestamp>`,
+# never `com.lobsterfarm.daemon` (id 1153).
+#
+# SECURITY NOTE — environment forwarding
+# --------------------------------------
+# The plist file at /tmp/<label>.plist is world-readable by default. We
+# therefore forward an explicit allowlist of non-sensitive environment
+# variables only (PATH, HOME, PNPM_HOME, NODE_ENV, LANG, LC_*, TERM, TMPDIR,
+# CI). Secrets — including OP_SERVICE_ACCOUNT_TOKEN, OP_SESSION_*, and any
+# other token-shaped vars — are deliberately NOT forwarded. If a test
+# command needs 1Password-injected secrets, run `op run --env-file <file>
+# -- scripts/run-tests-isolated.sh <cmd>` and have the inner command itself
+# call `op run` again — the secrets will be injected into the launchd
+# child's process env at exec time without ever touching disk in the plist.
+# (The `op` binary's session credentials live in the user keychain and are
+# accessed by the cli inside the bootstrapped service; they don't need to
+# travel through env vars.)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+  echo "usage: $(basename "$0") <command> [args...]" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Label & file paths
+# ---------------------------------------------------------------------------
+# Nanosecond timestamp keeps labels unique across concurrent agent sessions.
+# `gdate` (GNU coreutils) is preferred when available because BSD `date` on
+# macOS does not support %N. Fall back to PID-suffixed seconds otherwise.
+if command -v gdate >/dev/null 2>&1; then
+  TIMESTAMP="$(gdate +%s%N)"
+else
+  TIMESTAMP="$(date +%s)$$"
+fi
+
+LABEL="com.lobsterfarm.test.${TIMESTAMP}"
+PLIST="/tmp/${LABEL}.plist"
+STDOUT_FILE="/tmp/${LABEL}.out"
+STDERR_FILE="/tmp/${LABEL}.err"
+EXITCODE_FILE="/tmp/${LABEL}.exitcode"
+DOMAIN_TARGET="gui/${UID}/${LABEL}"
+DOMAIN="gui/${UID}"
+
+# ---------------------------------------------------------------------------
+# Cleanup trap — runs on normal exit, error, SIGINT, SIGTERM.
+# Idempotent so it's safe to invoke twice (EXIT will fire after INT/TERM).
+# ---------------------------------------------------------------------------
+CLEANED_UP=0
+TAIL_OUT_PID=""
+TAIL_ERR_PID=""
+
+cleanup() {
+  if [[ "${CLEANED_UP}" -eq 1 ]]; then
+    return
+  fi
+  CLEANED_UP=1
+
+  # Stop streaming tails first so they don't keep printing during/after bootout.
+  if [[ -n "${TAIL_OUT_PID}" ]] && kill -0 "${TAIL_OUT_PID}" 2>/dev/null; then
+    kill "${TAIL_OUT_PID}" 2>/dev/null || true
+    wait "${TAIL_OUT_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${TAIL_ERR_PID}" ]] && kill -0 "${TAIL_ERR_PID}" 2>/dev/null; then
+    kill "${TAIL_ERR_PID}" 2>/dev/null || true
+    wait "${TAIL_ERR_PID}" 2>/dev/null || true
+  fi
+
+  # Tear down the launchd service. `bootout` is the inverse of `bootstrap`;
+  # it stops the service and removes it from the user domain. If the service
+  # already exited cleanly, bootout still works (it removes the dormant
+  # entry); we suppress its output either way.
+  launchctl bootout "${DOMAIN_TARGET}" >/dev/null 2>&1 || true
+
+  # Remove temp artefacts. We keep them only on debug demand.
+  rm -f -- "${PLIST}" "${STDOUT_FILE}" "${STDERR_FILE}" "${EXITCODE_FILE}"
+}
+
+# Cleanup must fire on every exit path. On INT/TERM we exit with 128+sig
+# so the calling shell sees a sensible non-zero status; cleanup() is
+# idempotent and the EXIT trap will be a no-op the second time.
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+# ---------------------------------------------------------------------------
+# Build the wrapped command.
+#
+# We invoke the user's command via `/bin/bash -c '<cmd>; echo $? > <sentinel>'`
+# so that:
+#   - the exit code lands in a sentinel file (Option 1 from the spec)
+#   - we don't have to parse `launchctl print` output
+#   - the bash wrapper writes the sentinel atomically AFTER the command exits
+#
+# Each user-supplied argument is single-quote-escaped before being joined
+# into the bash command string. The escape rule for single-quoted shell:
+# replace every `'` with `'\''`.
+# ---------------------------------------------------------------------------
+shell_escape() {
+  local arg="$1"
+  printf "'%s'" "${arg//\'/\'\\\'\'}"
+}
+
+USER_CMD=""
+for arg in "$@"; do
+  if [[ -n "${USER_CMD}" ]]; then
+    USER_CMD+=" "
+  fi
+  USER_CMD+="$(shell_escape "${arg}")"
+done
+
+# The bash wrapper. Note: ${EXITCODE_FILE} is interpolated NOW (the path the
+# launchd child should write to); $? is escaped so it's evaluated by the
+# child's bash at runtime.
+WRAPPED_CMD="${USER_CMD}; echo \$? > $(shell_escape "${EXITCODE_FILE}")"
+
+# ---------------------------------------------------------------------------
+# Build EnvironmentVariables block — explicit allowlist only.
+# See SECURITY NOTE at top of file. Never add OP_*, AWS_*, GH_TOKEN, etc.
+# ---------------------------------------------------------------------------
+ENV_ALLOWLIST=(
+  PATH
+  HOME
+  PNPM_HOME
+  NODE_ENV
+  LANG
+  LC_ALL
+  LC_CTYPE
+  TERM
+  TMPDIR
+  CI
+)
+
+# XML-escape a string for safe inclusion in a plist <string> value.
+xml_escape() {
+  local s="$1"
+  s="${s//&/&amp;}"
+  s="${s//</&lt;}"
+  s="${s//>/&gt;}"
+  s="${s//\"/&quot;}"
+  s="${s//\'/&apos;}"
+  printf '%s' "${s}"
+}
+
+ENV_XML=""
+for var in "${ENV_ALLOWLIST[@]}"; do
+  if [[ -n "${!var:-}" ]]; then
+    ENV_XML+="        <key>$(xml_escape "${var}")</key>
+        <string>$(xml_escape "${!var}")</string>
+"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Working directory — capture at script invocation time.
+# ---------------------------------------------------------------------------
+WORKDIR="${PWD}"
+
+# ---------------------------------------------------------------------------
+# Write the plist.
+# ---------------------------------------------------------------------------
+cat >"${PLIST}" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$(xml_escape "${LABEL}")</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>$(xml_escape "${WRAPPED_CMD}")</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$(xml_escape "${WORKDIR}")</string>
+    <key>StandardOutPath</key>
+    <string>$(xml_escape "${STDOUT_FILE}")</string>
+    <key>StandardErrorPath</key>
+    <string>$(xml_escape "${STDERR_FILE}")</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>AbandonProcessGroup</key>
+    <false/>
+    <key>EnvironmentVariables</key>
+    <dict>
+${ENV_XML}    </dict>
+</dict>
+</plist>
+PLIST_EOF
+
+# Sanity-check the plist; if it's malformed launchctl will fail with a
+# cryptic message, so we surface the parser error early.
+if ! plutil -lint "${PLIST}" >/dev/null; then
+  echo "run-tests-isolated: generated plist failed plutil -lint" >&2
+  plutil -lint "${PLIST}" >&2 || true
+  exit 1
+fi
+
+# Pre-create the out/err files so `tail -f` has something to attach to
+# without racing the service's first write.
+: >"${STDOUT_FILE}"
+: >"${STDERR_FILE}"
+
+# ---------------------------------------------------------------------------
+# Bootstrap into the user's launchd domain. This is the load-bearing step:
+# the new process gets a fresh resource coalition named after LABEL.
+# ---------------------------------------------------------------------------
+if ! launchctl bootstrap "${DOMAIN}" "${PLIST}"; then
+  echo "run-tests-isolated: launchctl bootstrap ${DOMAIN} ${PLIST} failed" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Stream stdout/stderr to the calling terminal in real time.
+# `tail -F` follows by name and is robust to file replacement; `-n +1`
+# starts from the beginning so we don't miss early output.
+# ---------------------------------------------------------------------------
+tail -n +1 -F "${STDOUT_FILE}" 2>/dev/null &
+TAIL_OUT_PID=$!
+tail -n +1 -F "${STDERR_FILE}" >&2 2>/dev/null &
+TAIL_ERR_PID=$!
+
+# ---------------------------------------------------------------------------
+# Wait for the sentinel exit-code file. Poll at 200 ms; that's frequent
+# enough to feel instant on completion and cheap enough to be invisible.
+# ---------------------------------------------------------------------------
+while [[ ! -s "${EXITCODE_FILE}" ]]; do
+  sleep 0.2
+done
+
+# Give tail one more tick to drain final buffered writes before we kill it.
+sleep 0.3
+
+EXIT_CODE="$(tr -d '[:space:]' <"${EXITCODE_FILE}")"
+if [[ -z "${EXIT_CODE}" ]] || ! [[ "${EXIT_CODE}" =~ ^[0-9]+$ ]]; then
+  echo "run-tests-isolated: malformed exit code in ${EXITCODE_FILE}: '${EXIT_CODE}'" >&2
+  EXIT_CODE=1
+fi
+
+# cleanup() runs via EXIT trap.
+exit "${EXIT_CODE}"

--- a/scripts/run-tests-isolated.sh
+++ b/scripts/run-tests-isolated.sh
@@ -150,7 +150,12 @@ trap 'cleanup; exit 143' TERM
 # ---------------------------------------------------------------------------
 shell_escape() {
   local arg="$1"
-  printf "'%s'" "${arg//\'/\'\\\'\'}"
+  # Use a local variable for the single quote so bash's parameter-expansion
+  # parser doesn't get tangled trying to balance literal `'` characters in
+  # the replacement pattern. The substitution rule is: every `'` becomes
+  # `'\''` (close-quote, escaped-quote, open-quote).
+  local -r SQ="'"
+  printf "'%s'" "${arg//$SQ/$SQ\\$SQ$SQ}"
 }
 
 USER_CMD=""

--- a/scripts/run-tests-isolated.sh
+++ b/scripts/run-tests-isolated.sh
@@ -293,8 +293,47 @@ TAIL_ERR_PID=$!
 # ---------------------------------------------------------------------------
 # Wait for the sentinel exit-code file. Poll at 200 ms; that's frequent
 # enough to feel instant on completion and cheap enough to be invisible.
+#
+# Two safety nets so we never loop forever:
+#   1. `launchctl print` state canary — if the inner bash crashed (SIGKILL,
+#      OOM, machine pressure) without writing the sentinel, the service
+#      stays registered but transitions to `state = not running` and the
+#      `pid = N` line disappears. We treat absence of a `pid =` line as
+#      "process is gone." (`launchctl print` itself still returns 0 for a
+#      registered-but-dead service, so the exit status is unreliable; we
+#      have to grep the body.)
+#   2. 30-minute hard cap — backstop in case the canary itself is unreliable
+#      (e.g. launchd output format changes in a future macOS). Generous:
+#      the full daemon test suite is ~10s and `pnpm -r test` was ~30s in
+#      validation, so 30 min covers any plausible legitimate run.
 # ---------------------------------------------------------------------------
+POLL_DEADLINE=$(( $(date +%s) + 1800 ))
 while [[ ! -s "${EXITCODE_FILE}" ]]; do
+  if (( $(date +%s) > POLL_DEADLINE )); then
+    echo "run-tests-isolated: timed out after 30m waiting for sentinel; service may have crashed" >&2
+    exit 1
+  fi
+  # Re-read print output each tick. If the service is unregistered (rc!=0)
+  # OR registered but has no pid line, the inner process is gone without
+  # having written the sentinel.
+  if ! PRINT_OUT="$(launchctl print "${DOMAIN_TARGET}" 2>/dev/null)"; then
+    echo "run-tests-isolated: service no longer registered without writing exit code sentinel (likely SIGKILL/OOM)" >&2
+    exit 1
+  fi
+  if ! grep -qE '^[[:space:]]*pid[[:space:]]*=[[:space:]]*[0-9]+' <<<"${PRINT_OUT}"; then
+    # Tiny grace window: launchd may report the service as registered before
+    # it has assigned a pid right after bootstrap. Re-check after a tick;
+    # if still no pid AND the sentinel is still empty, declare crash.
+    sleep 0.2
+    if [[ -s "${EXITCODE_FILE}" ]]; then
+      break
+    fi
+    PRINT_OUT="$(launchctl print "${DOMAIN_TARGET}" 2>/dev/null || true)"
+    if ! grep -qE '^[[:space:]]*pid[[:space:]]*=[[:space:]]*[0-9]+' <<<"${PRINT_OUT}"; then
+      echo "run-tests-isolated: service exited without writing exit code sentinel (likely SIGKILL/OOM)" >&2
+      exit 1
+    fi
+  fi
   sleep 0.2
 done
 

--- a/scripts/run-tests-isolated.sh
+++ b/scripts/run-tests-isolated.sh
@@ -246,6 +246,11 @@ ${ENV_XML}    </dict>
 </plist>
 PLIST_EOF
 
+# Lock down /tmp artefacts to 0600 — they live in a world-readable directory
+# and the plist exposes the full command line, working directory, and any
+# allowlisted env var values. Even on a single-user box this is basic hygiene.
+chmod 0600 "${PLIST}"
+
 # Sanity-check the plist; if it's malformed launchctl will fail with a
 # cryptic message, so we surface the parser error early.
 if ! plutil -lint "${PLIST}" >/dev/null; then
@@ -255,9 +260,16 @@ if ! plutil -lint "${PLIST}" >/dev/null; then
 fi
 
 # Pre-create the out/err files so `tail -f` has something to attach to
-# without racing the service's first write.
+# without racing the service's first write. chmod immediately so launchd's
+# subsequent appends inherit the restrictive mode.
 : >"${STDOUT_FILE}"
+chmod 0600 "${STDOUT_FILE}"
 : >"${STDERR_FILE}"
+chmod 0600 "${STDERR_FILE}"
+# Pre-create the exit-code file too; the inner bash will overwrite it via
+# `echo $? > …` but starting with 0600 means there's no brief 0644 window.
+: >"${EXITCODE_FILE}"
+chmod 0600 "${EXITCODE_FILE}"
 
 # ---------------------------------------------------------------------------
 # Bootstrap into the user's launchd domain. This is the load-bearing step:


### PR DESCRIPTION
## Summary

Adds `scripts/run-tests-isolated.sh`, a shell wrapper that launches an arbitrary command inside its own macOS resource coalition by bootstrapping a one-shot LaunchAgent. This breaks coalition inheritance from the LobsterFarm daemon (id 1153) so test runs from agent sessions get a fresh 2 GiB / 24h dirty-write budget — eliminating the SIGKILL kill path documented in #28 and confirmed in the #35 investigation.

- `scripts/run-tests-isolated.sh <cmd> [args...]` — generates a unique label `com.lobsterfarm.test.<unix-ns>`, writes a one-shot plist to `/tmp/<label>.plist`, `launchctl bootstrap`s into `gui/$UID`, streams stdout/stderr live via `tail -F`, polls a sentinel `/tmp/<label>.exitcode` for completion, and cleans up via an idempotent EXIT/INT/TERM trap.
- `coding-dna/SKILL.md` "Running tests in agent worktrees" rewritten — `scripts/run-tests-isolated.sh pnpm -r test` is now the primary recommended path; `pnpm --filter <package>` is documented as the fallback for older worktrees / non-launchd contexts.
- `scripts/README.md` added per readme-guideline.

## Mechanism (the why)

macOS resource coalitions are set at `posix_spawn` time and inherit from the spawning process. Setsid, nohup, sudo, sandbox-exec, and `launchctl asuser` all leave the spawned process in the parent's coalition (empirically ruled out in PRs #34 and #35). The only userspace mechanism that creates a fresh coalition on a SIP-enabled host is `launchctl bootstrap` — launchd holds the private entitlement `com.apple.private.coalition-policy` and can call `coalition_create()` on our behalf. A process started this way runs in a brand-new coalition named after the plist's `Label`, with its own fresh budget. Children of that process inherit the new coalition, not 1153.

## Security note (env forwarding)

The plist file at `/tmp/<label>.plist` is world-readable by default. The wrapper therefore forwards an explicit allowlist only: `PATH`, `HOME`, `PNPM_HOME`, `NODE_ENV`, `LANG`, `LC_*`, `TERM`, `TMPDIR`, `CI`. Token-shaped vars (`OP_*`, `AWS_*`, `GH_TOKEN`, etc.) are **never** written to disk in the plist. Tests needing 1Password should call `op run` inside the wrapped command (e.g. `scripts/run-tests-isolated.sh bash -c 'op run --env-file .env.op -- pnpm test'`), not rely on env-passthrough.

## Test plan

All acceptance criteria from the issue verified empirically on the agent host:

- [x] `scripts/run-tests-isolated.sh pnpm -r test` runs the full test suite (1158 daemon tests + cli + shared) from the agent session — exit 0, no SIGKILL.
- [x] `launchctl print pid/<vitest-worker-pid> | grep coalition` shows `name = com.lobsterfarm.test.<ts>` (e.g. `com.lobsterfarm.test.17778607455188`), **not** `com.lobsterfarm.daemon` (1153).
- [x] Exit code propagated correctly — verified with both `exit 0` and `exit 42` wrapped commands.
- [x] stdout and stderr visible in real time during the run (live `tail -F` of the plist's StandardOut/ErrPath).
- [x] Service cleans up on normal exit — `launchctl print gui/$UID` shows no leaked services, `/tmp/com.lobsterfarm.test.*` empty.
- [x] Service cleans up on Ctrl-C — verified with `expect` driving a real pty: wrapper exits 130, no leaked service or plist files.
- [x] Service cleans up on SIGTERM — verified the same way; wrapper exits cleanly, no leaks.
- [x] `coding-dna/SKILL.md` updated — primary path is the wrapper, fallback is `pnpm --filter`.
- [x] Script has a header comment block explaining the coalition mechanism, not just the what.

## Out of scope

- Persistent launchd agent for test running (Option A "full" from #35) — the dynamic bootstrap is sufficient.
- Daemon plist or daemon-startup changes.
- vitest config changes — `maxForks: 4` from PR #34 stays as belt-and-suspenders.

Closes #36

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>