### PR TITLE
feat(daemon): stop-hook reply enforcement

### DIFF
--- a/packages/cli/src/commands/init/generate.ts
+++ b/packages/cli/src/commands/init/generate.ts
@@ -249,8 +249,21 @@ export async function generate_settings(path_overrides?: Partial<PathConfig>): P
           hooks: [
             {
               type: "command",
+              // Reply-enforcement (issue #39): the daemon may instruct us to
+              // block this turn (exit 2 with stderr reminder) when the agent
+              // produced assistant text but didn't route it through Discord.
+              // On any other condition (or if curl/jq fail / daemon
+              // unreachable), exit 0 — a wedged daemon must never wedge an
+              // agent.
               command:
-                'curl -s -X POST http://localhost:7749/hooks/stop -H \'Content-Type: application/json\' -d \'{"session_id": "\'"$CLAUDE_SESSION_ID"\'", "working_dir": "\'"$(pwd)"\'"}\' || true',
+                "RESP=$(curl -s -X POST http://localhost:7749/hooks/stop " +
+                "-H 'Content-Type: application/json' " +
+                '-d \'{"session_id": "\'"$CLAUDE_SESSION_ID"\'", "working_dir": "\'"$(pwd)"\'"}\' 2>/dev/null) || exit 0; ' +
+                "if echo \"$RESP\" | jq -e '.block == true' >/dev/null 2>&1; then " +
+                "echo \"$RESP\" | jq -r '.reminder' >&2; " +
+                "exit 2; " +
+                "fi; " +
+                "exit 0",
               timeout: 10,
             },
           ],

--- a/packages/daemon/src/__tests__/reply-enforcement.test.ts
+++ b/packages/daemon/src/__tests__/reply-enforcement.test.ts
@@ -1,0 +1,561 @@
+/**
+ * Tests for reply-enforcement.ts (issue #39).
+ *
+ * Covers all acceptance-criteria checkboxes from the issue spec:
+ *   - text + reply  → ok, no enforcement (Discord-bound + non-bound)
+ *   - text + no-reply, bound → block + reminder
+ *   - text + no-reply, NOT bound → ok pass-through
+ *   - silent turn, bound → heartbeat posted
+ *   - silent turn within cooldown → no second heartbeat
+ *   - silent turn, NOT bound → no heartbeat, no error
+ *   - subagent / sidechain → pass-through
+ *   - JSONL flush race → retry loop tolerates a brief absence
+ *   - Haiku timeout → graceful fail open
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { DiscordBot } from "../discord.js";
+import { encode_project_slug } from "../pool.js";
+import type { BotPool, PoolBot } from "../pool.js";
+import {
+  HEARTBEAT_COOLDOWN_MS,
+  HEARTBEAT_PREFIX,
+  REPLY_REMINDER,
+  _reset_cooldown_for_tests,
+  evaluate_stop,
+  is_discord_bound,
+  parse_last_assistant_turn,
+  read_last_assistant_turn,
+  resolve_bound_channel,
+} from "../reply-enforcement.js";
+import type { TurnSummary } from "../reply-enforcement.js";
+
+// ── Test helpers ──
+
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    session_confirmed: true,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    assigned_at: null,
+    state_dir: `/tmp/test-${String(overrides.id)}`,
+    model: null,
+    effort: null,
+    last_avatar_archetype: null,
+    last_avatar_set_at: null,
+    ...overrides,
+  };
+}
+
+/** Minimal pool stub exposing only the surface evaluate_stop touches. */
+function make_pool(bots: PoolBot[]): BotPool {
+  return {
+    get_assigned_bots(): readonly PoolBot[] {
+      return bots.filter((b) => b.state === "assigned");
+    },
+  } as unknown as BotPool;
+}
+
+interface SendCall {
+  channel_id: string;
+  content: string;
+}
+
+function make_discord(): { discord: DiscordBot; sends: SendCall[] } {
+  const sends: SendCall[] = [];
+  const discord = {
+    async send(channel_id: string, content: string) {
+      sends.push({ channel_id, content });
+    },
+  } as unknown as DiscordBot;
+  return { discord, sends };
+}
+
+/** Build a JSONL "assistant" event with the given content blocks. */
+function assistant_line(opts: {
+  text?: string;
+  tools?: string[];
+  is_sidechain?: boolean;
+}): string {
+  const blocks: Array<Record<string, unknown>> = [];
+  if (opts.text !== undefined) {
+    blocks.push({ type: "text", text: opts.text });
+  }
+  for (const name of opts.tools ?? []) {
+    blocks.push({ type: "tool_use", id: `t-${name}`, name, input: {} });
+  }
+  return JSON.stringify({
+    type: "assistant",
+    isSidechain: opts.is_sidechain === true,
+    message: {
+      role: "assistant",
+      content: blocks,
+    },
+  });
+}
+
+function user_line(): string {
+  return JSON.stringify({
+    type: "user",
+    message: { role: "user", content: [{ type: "text", text: "hi" }] },
+  });
+}
+
+beforeEach(() => {
+  _reset_cooldown_for_tests();
+});
+
+// ── parse_last_assistant_turn ──
+
+describe("parse_last_assistant_turn", () => {
+  it("flags produced_text when last assistant turn has non-empty text", () => {
+    const jsonl = `${user_line()}\n${assistant_line({ text: "Hello there." })}\n`;
+    const turn = parse_last_assistant_turn(jsonl);
+    expect(turn.found).toBe(true);
+    expect(turn.produced_text).toBe(true);
+    expect(turn.called_reply).toBe(false);
+  });
+
+  it("ignores whitespace-only text blocks", () => {
+    const jsonl = `${assistant_line({ text: "   \n\t" })}\n`;
+    expect(parse_last_assistant_turn(jsonl).produced_text).toBe(false);
+  });
+
+  it("flags called_reply when the canonical Discord reply tool is invoked", () => {
+    const jsonl = `${assistant_line({
+      text: "ok",
+      tools: ["mcp__plugin_discord_discord__reply"],
+    })}\n`;
+    const turn = parse_last_assistant_turn(jsonl);
+    expect(turn.called_reply).toBe(true);
+    expect(turn.produced_text).toBe(true);
+  });
+
+  it("loose-matches future discord-reply-shaped tool names", () => {
+    const jsonl = `${assistant_line({ tools: ["discord_v2_reply"] })}\n`;
+    expect(parse_last_assistant_turn(jsonl).called_reply).toBe(true);
+  });
+
+  it("does not flag non-reply tools as reply", () => {
+    const jsonl = `${assistant_line({ tools: ["Bash", "Read", "Edit"] })}\n`;
+    const turn = parse_last_assistant_turn(jsonl);
+    expect(turn.called_reply).toBe(false);
+    expect(turn.tool_summary).toBe("Bash, Read, Edit");
+  });
+
+  it("walks backward to the *last* assistant turn, ignoring earlier ones", () => {
+    const jsonl = [
+      assistant_line({ text: "old reply", tools: ["mcp__plugin_discord_discord__reply"] }),
+      user_line(),
+      assistant_line({ tools: ["Bash"] }), // last assistant turn = silent
+      "",
+    ].join("\n");
+    const turn = parse_last_assistant_turn(jsonl);
+    expect(turn.produced_text).toBe(false);
+    expect(turn.called_reply).toBe(false);
+    expect(turn.tool_summary).toBe("Bash");
+  });
+
+  it("propagates isSidechain marker", () => {
+    const jsonl = `${assistant_line({ text: "subagent text", is_sidechain: true })}\n`;
+    expect(parse_last_assistant_turn(jsonl).is_sidechain).toBe(true);
+  });
+
+  it("returns found=false on empty / no-assistant transcripts", () => {
+    expect(parse_last_assistant_turn("").found).toBe(false);
+    expect(parse_last_assistant_turn(`${user_line()}\n`).found).toBe(false);
+  });
+
+  it("skips malformed lines without throwing", () => {
+    const jsonl = `not json\n${assistant_line({ text: "ok" })}\n`;
+    expect(parse_last_assistant_turn(jsonl).found).toBe(true);
+  });
+});
+
+// ── read_last_assistant_turn (filesystem + flush race) ──
+
+describe("read_last_assistant_turn", () => {
+  let original_home: string | undefined;
+  let temp_home: string;
+  let working_dir: string;
+  let session_id: string;
+
+  beforeEach(async () => {
+    original_home = process.env.HOME;
+    temp_home = await mkdtemp(join(tmpdir(), "lf-stop-hook-"));
+    process.env.HOME = temp_home;
+
+    working_dir = "/tmp/some-cwd";
+    session_id = "11111111-1111-1111-1111-111111111111";
+
+    const project_dir = join(temp_home, ".claude", "projects", encode_project_slug(working_dir));
+    await mkdir(project_dir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (original_home !== undefined) {
+      process.env.HOME = original_home;
+    } else {
+      delete process.env.HOME;
+    }
+    await rm(temp_home, { recursive: true, force: true });
+  });
+
+  it("returns found=false when the JSONL doesn't exist", async () => {
+    const turn = await read_last_assistant_turn(working_dir, session_id);
+    expect(turn.found).toBe(false);
+  });
+
+  it("reads the last assistant turn from disk", async () => {
+    const path = join(
+      temp_home,
+      ".claude",
+      "projects",
+      encode_project_slug(working_dir),
+      `${session_id}.jsonl`,
+    );
+    await writeFile(path, `${assistant_line({ text: "hello" })}\n`, "utf-8");
+    const turn = await read_last_assistant_turn(working_dir, session_id);
+    expect(turn.found).toBe(true);
+    expect(turn.produced_text).toBe(true);
+  });
+
+  it("tolerates a brief flush delay (race mitigation)", async () => {
+    const path = join(
+      temp_home,
+      ".claude",
+      "projects",
+      encode_project_slug(working_dir),
+      `${session_id}.jsonl`,
+    );
+
+    // Materialize the file ~25ms after the call begins.
+    setTimeout(() => {
+      void writeFile(path, `${assistant_line({ text: "late flush" })}\n`, "utf-8");
+    }, 25);
+
+    const turn = await read_last_assistant_turn(working_dir, session_id);
+    expect(turn.found).toBe(true);
+    expect(turn.produced_text).toBe(true);
+  });
+});
+
+// ── Pool binding ──
+
+describe("resolve_bound_channel / is_discord_bound", () => {
+  it("returns the channel_id when an assigned bot owns the session", () => {
+    const pool = make_pool([
+      make_bot({
+        id: 1,
+        state: "assigned",
+        channel_id: "C123",
+        entity_id: "lobster-farm",
+        session_id: "S1",
+      }),
+    ]);
+    expect(resolve_bound_channel("S1", pool)).toBe("C123");
+    expect(is_discord_bound("S1", pool)).toBe(true);
+  });
+
+  it("returns null when no assigned bot owns the session", () => {
+    const pool = make_pool([
+      make_bot({
+        id: 1,
+        state: "assigned",
+        channel_id: "C123",
+        session_id: "S2",
+      }),
+    ]);
+    expect(resolve_bound_channel("S1", pool)).toBeNull();
+    expect(is_discord_bound("S1", pool)).toBe(false);
+  });
+
+  it("ignores non-assigned bots even with matching session_id", () => {
+    const pool = make_pool([
+      make_bot({ id: 1, state: "free", session_id: "S1", channel_id: "C-stale" }),
+      make_bot({ id: 2, state: "parked", session_id: "S1", channel_id: "C-also-stale" }),
+    ]);
+    expect(is_discord_bound("S1", pool)).toBe(false);
+  });
+
+  it("returns null when pool is null", () => {
+    expect(resolve_bound_channel("S1", null)).toBeNull();
+    expect(is_discord_bound("S1", null)).toBe(false);
+  });
+});
+
+// ── evaluate_stop orchestrator ──
+
+describe("evaluate_stop — acceptance criteria", () => {
+  const session_id = "abc";
+  const working_dir = "/tmp/wd";
+
+  function bound_pool(): BotPool {
+    return make_pool([
+      make_bot({
+        id: 1,
+        state: "assigned",
+        channel_id: "C123",
+        entity_id: "lobster-farm",
+        session_id,
+      }),
+    ]);
+  }
+
+  function unbound_pool(): BotPool {
+    return make_pool([
+      make_bot({
+        id: 1,
+        state: "assigned",
+        channel_id: "C123",
+        entity_id: "lobster-farm",
+        session_id: "different-session",
+      }),
+    ]);
+  }
+
+  function make_turn_reader(turn: Partial<TurnSummary>) {
+    return async (): Promise<TurnSummary> => ({
+      produced_text: false,
+      called_reply: false,
+      is_sidechain: false,
+      tool_summary: "",
+      found: true,
+      ...turn,
+    });
+  }
+
+  it("text + reply → ok pass-through (Discord-bound)", async () => {
+    const { discord, sends } = make_discord();
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: bound_pool(),
+        discord,
+        read_turn: make_turn_reader({ produced_text: true, called_reply: true }),
+        make_heartbeat: async () => "should not run",
+      },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(sends.length).toBe(0);
+  });
+
+  it("text + no-reply, Discord-bound → block + reminder", async () => {
+    const { discord, sends } = make_discord();
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: bound_pool(),
+        discord,
+        read_turn: make_turn_reader({ produced_text: true, called_reply: false }),
+      },
+    );
+    expect(result).toEqual({ ok: true, block: true, reminder: REPLY_REMINDER });
+    // Must NOT post a heartbeat on the blocked path.
+    expect(sends.length).toBe(0);
+  });
+
+  it("text + no-reply, NOT Discord-bound → pass-through (no enforcement)", async () => {
+    const { discord, sends } = make_discord();
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: unbound_pool(),
+        discord,
+        read_turn: make_turn_reader({ produced_text: true, called_reply: false }),
+      },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(sends.length).toBe(0);
+  });
+
+  it("silent turn (tool-only), Discord-bound → posts heartbeat to channel", async () => {
+    const { discord, sends } = make_discord();
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: bound_pool(),
+        discord,
+        read_turn: make_turn_reader({
+          produced_text: false,
+          called_reply: false,
+          tool_summary: "Bash, Edit",
+        }),
+        make_heartbeat: async () => "Refactoring the pool resume logic.",
+      },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(sends).toEqual([
+      {
+        channel_id: "C123",
+        content: `${HEARTBEAT_PREFIX}Refactoring the pool resume logic.`,
+      },
+    ]);
+  });
+
+  it("silent turn within cooldown window → no second heartbeat", async () => {
+    const { discord, sends } = make_discord();
+    let now = 1_000_000;
+    const deps = {
+      pool: bound_pool(),
+      discord,
+      now: () => now,
+      read_turn: make_turn_reader({
+        produced_text: false,
+        called_reply: false,
+        tool_summary: "Bash",
+      }),
+      make_heartbeat: async () => "Working on something.",
+    };
+
+    await evaluate_stop({ session_id, working_dir }, deps);
+    expect(sends.length).toBe(1);
+
+    // Same channel, 30 seconds later — well inside the 60s cooldown.
+    now += 30_000;
+    expect(now - 1_000_000).toBeLessThan(HEARTBEAT_COOLDOWN_MS);
+    await evaluate_stop({ session_id, working_dir }, deps);
+    expect(sends.length).toBe(1);
+
+    // After cooldown expires, a new heartbeat may post.
+    now += HEARTBEAT_COOLDOWN_MS + 1;
+    await evaluate_stop({ session_id, working_dir }, deps);
+    expect(sends.length).toBe(2);
+  });
+
+  it("silent turn, NOT Discord-bound → no heartbeat, no error", async () => {
+    const { discord, sends } = make_discord();
+    let heartbeat_called = false;
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: unbound_pool(),
+        discord,
+        read_turn: make_turn_reader({ produced_text: false, called_reply: false }),
+        make_heartbeat: async () => {
+          heartbeat_called = true;
+          return "should not run";
+        },
+      },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(sends.length).toBe(0);
+    expect(heartbeat_called).toBe(false);
+  });
+
+  it("subagent / sidechain transcript → pass-through even on text+no-reply", async () => {
+    // Defense-in-depth: even if a sidechain session were somehow bound
+    // (it shouldn't be, but the pool check is the only other line of defense),
+    // the sidechain marker forces pass-through.
+    const { discord, sends } = make_discord();
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: bound_pool(),
+        discord,
+        read_turn: make_turn_reader({
+          produced_text: true,
+          called_reply: false,
+          is_sidechain: true,
+        }),
+      },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(sends.length).toBe(0);
+  });
+
+  it("transcript not found → pass-through (no false-positive block)", async () => {
+    const { discord, sends } = make_discord();
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: bound_pool(),
+        discord,
+        read_turn: make_turn_reader({ found: false }),
+      },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(sends.length).toBe(0);
+  });
+
+  it("transcript reader throws → fail open (no block)", async () => {
+    const { discord, sends } = make_discord();
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: bound_pool(),
+        discord,
+        read_turn: async () => {
+          throw new Error("boom");
+        },
+      },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(sends.length).toBe(0);
+  });
+
+  it("Haiku heartbeat throws → swallow error, no send, no cooldown burn", async () => {
+    const { discord, sends } = make_discord();
+    let now = 0;
+    const deps = {
+      pool: bound_pool(),
+      discord,
+      now: () => now,
+      read_turn: make_turn_reader({ produced_text: false, called_reply: false }),
+      make_heartbeat: async () => {
+        throw new Error("haiku timed out");
+      },
+    };
+    const result = await evaluate_stop({ session_id, working_dir }, deps);
+    expect(result).toEqual({ ok: true });
+    expect(sends.length).toBe(0);
+
+    // Cooldown was NOT marked because the send never landed — next call
+    // (with a working heartbeat) should be free to post.
+    const second = {
+      ...deps,
+      make_heartbeat: async () => "Now working.",
+    };
+    now += 1_000;
+    await evaluate_stop({ session_id, working_dir }, second);
+    expect(sends.length).toBe(1);
+  });
+
+  it("mid-turn streaming reply (no text + reply called) → pass-through, no heartbeat", async () => {
+    const { discord, sends } = make_discord();
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: bound_pool(),
+        discord,
+        read_turn: make_turn_reader({ produced_text: false, called_reply: true }),
+        make_heartbeat: async () => "should not run",
+      },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(sends.length).toBe(0);
+  });
+
+  it("null pool (daemon without Discord) → pass-through", async () => {
+    const { discord, sends } = make_discord();
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: null,
+        discord,
+        read_turn: make_turn_reader({ produced_text: true, called_reply: false }),
+      },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(sends.length).toBe(0);
+  });
+});

--- a/packages/daemon/src/reply-enforcement.ts
+++ b/packages/daemon/src/reply-enforcement.ts
@@ -1,0 +1,403 @@
+/**
+ * Stop-hook reply enforcement.
+ *
+ * On every Claude Code Stop hook fire, the daemon decides whether the agent's
+ * last turn was correctly routed to its bound Discord channel:
+ *
+ *   produced_text  called_reply   action
+ *   ─────────────  ────────────   ─────────────────────────────────────────
+ *   true           true           pass through (normal)
+ *   true           false          block: hook script exits 2 with reminder
+ *   false          true           pass through (mid-turn streaming reply)
+ *   false          false          heartbeat: daemon posts Haiku-summary itself
+ *
+ * Non-Discord-bound sessions (CLI agents, subagents, queue tasks) always pass
+ * through. Heartbeats are debounced per-channel to avoid spam.
+ *
+ * See issue #39 for the full spec.
+ */
+
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import type { DiscordBot } from "./discord.js";
+import { claude_session_jsonl_path } from "./pool.js";
+import type { BotPool } from "./pool.js";
+import * as sentry from "./sentry.js";
+
+const exec = promisify(execFile);
+
+// ── Tool name constants ──
+
+/**
+ * Discord output tool names that count as "the agent routed its message."
+ * The MCP plugin namespace can drift over time — keep this list narrow but
+ * forgiving (any tool whose name contains both "discord" and "reply"
+ * qualifies, see `is_reply_tool_name`).
+ */
+const DISCORD_REPLY_TOOL_NAMES: readonly string[] = [
+  "mcp__plugin_discord_discord__reply",
+  "mcp__plugin_discord_discord__edit_message",
+];
+
+/** Loose match for any future Discord reply-shaped tool we haven't listed. */
+function is_reply_tool_name(name: string): boolean {
+  if (DISCORD_REPLY_TOOL_NAMES.includes(name)) return true;
+  const lower = name.toLowerCase();
+  return lower.includes("discord") && lower.includes("reply");
+}
+
+// ── Types ──
+
+export interface TurnSummary {
+  /** True if the last assistant turn produced a non-empty text content block. */
+  produced_text: boolean;
+  /** True if the last assistant turn called a Discord reply tool. */
+  called_reply: boolean;
+  /** True if the last assistant turn was a sidechain (subagent) message. */
+  is_sidechain: boolean;
+  /**
+   * Comma-separated list of tool names invoked in the last assistant turn,
+   * used by the heartbeat generator. May be empty when the turn was pure text.
+   */
+  tool_summary: string;
+  /** True if a transcript was found and parsed. False = no JSONL on disk yet. */
+  found: boolean;
+}
+
+export type StopHookResponse =
+  | { ok: true; block?: false }
+  | { ok: true; block: true; reminder: string };
+
+export interface EvaluateStopDeps {
+  pool: BotPool | null;
+  discord: DiscordBot | null;
+  /** Override clock for tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Override transcript reader for tests. */
+  read_turn?: (working_dir: string, session_id: string) => Promise<TurnSummary>;
+  /** Override Haiku heartbeat generator for tests. */
+  make_heartbeat?: (turn: TurnSummary) => Promise<string>;
+}
+
+// ── Cooldown ──
+
+/** Default per-channel heartbeat cooldown (ms). */
+export const HEARTBEAT_COOLDOWN_MS = 60_000;
+
+interface CooldownEntry {
+  channel_id: string;
+  last_at: number;
+}
+
+/** Module-level cooldown map. Channels heartbeated within HEARTBEAT_COOLDOWN_MS
+ * are skipped on subsequent silent turns. */
+const heartbeat_cooldown = new Map<string, CooldownEntry>();
+
+/** Reset cooldowns. Test-only. */
+export function _reset_cooldown_for_tests(): void {
+  heartbeat_cooldown.clear();
+}
+
+function in_cooldown(channel_id: string, now: number): boolean {
+  const entry = heartbeat_cooldown.get(channel_id);
+  if (!entry) return false;
+  return now - entry.last_at < HEARTBEAT_COOLDOWN_MS;
+}
+
+function mark_cooldown(channel_id: string, now: number): void {
+  heartbeat_cooldown.set(channel_id, { channel_id, last_at: now });
+}
+
+// ── Transcript parsing ──
+
+/**
+ * Locate and read the last assistant turn from a session's JSONL transcript.
+ *
+ * Mitigates the transcript-tail flush race: Claude Code writes the JSONL
+ * asynchronously, so the Stop hook may fire before the last events have hit
+ * disk. We retry with a short backoff up to ~250ms.
+ *
+ * Returns `found: false` when the transcript does not exist yet (e.g. brand
+ * new session) — the caller treats this as "pass through, nothing to enforce".
+ */
+export async function read_last_assistant_turn(
+  working_dir: string,
+  session_id: string,
+): Promise<TurnSummary> {
+  const path = claude_session_jsonl_path(working_dir, session_id);
+
+  // Brief retry loop to mitigate the JSONL flush race: Claude Code writes the
+  // transcript asynchronously, so the Stop hook may fire before the last
+  // events have hit disk. Retry with backoff, capped at ~250ms total. Settle
+  // early once the file size stops growing — single syscall per attempt.
+  const delays = [0, 50, 100, 100];
+  let last_size = -1;
+  let content = "";
+
+  for (const delay of delays) {
+    if (delay > 0) {
+      await new Promise((r) => setTimeout(r, delay));
+    }
+    let next: string;
+    try {
+      next = await readFile(path, "utf-8");
+    } catch {
+      // File not yet written.
+      continue;
+    }
+    if (next.length === last_size) {
+      break;
+    }
+    last_size = next.length;
+    content = next;
+  }
+
+  if (!content) {
+    return {
+      produced_text: false,
+      called_reply: false,
+      is_sidechain: false,
+      tool_summary: "",
+      found: false,
+    };
+  }
+
+  return parse_last_assistant_turn(content);
+}
+
+interface JsonlEntry {
+  type?: string;
+  isSidechain?: boolean;
+  message?: {
+    role?: string;
+    content?: Array<{
+      type?: string;
+      text?: string;
+      name?: string;
+    }>;
+  };
+}
+
+/**
+ * Pure transcript parser. Walks lines from the tail backward and returns the
+ * summary of the most recent `type === "assistant"` entry.
+ *
+ * Exported for unit tests so we don't have to touch the filesystem.
+ */
+export function parse_last_assistant_turn(jsonl_content: string): TurnSummary {
+  const lines = jsonl_content.split("\n");
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line) continue;
+
+    let entry: JsonlEntry;
+    try {
+      entry = JSON.parse(line) as JsonlEntry;
+    } catch {
+      continue;
+    }
+
+    if (entry.type !== "assistant") continue;
+
+    const content = entry.message?.content ?? [];
+    let produced_text = false;
+    let called_reply = false;
+    const tool_names: string[] = [];
+
+    for (const block of content) {
+      if (block.type === "text" && typeof block.text === "string" && block.text.trim() !== "") {
+        produced_text = true;
+      }
+      if (block.type === "tool_use" && typeof block.name === "string") {
+        tool_names.push(block.name);
+        if (is_reply_tool_name(block.name)) {
+          called_reply = true;
+        }
+      }
+    }
+
+    return {
+      produced_text,
+      called_reply,
+      is_sidechain: entry.isSidechain === true,
+      tool_summary: tool_names.join(", "),
+      found: true,
+    };
+  }
+
+  return {
+    produced_text: false,
+    called_reply: false,
+    is_sidechain: false,
+    tool_summary: "",
+    found: false,
+  };
+}
+
+// ── Discord-bound check ──
+
+/**
+ * Resolve the Discord channel a session is bound to, if any.
+ *
+ * A session is "Discord-bound" iff there is an *assigned* pool bot whose
+ * `session_id` matches and whose `channel_id` is set. Subagents (sidechain
+ * sessions) and queue tasks are never directly bound — their session ids
+ * never appear in the pool's assignment map.
+ */
+export function resolve_bound_channel(session_id: string, pool: BotPool | null): string | null {
+  if (!pool) return null;
+  for (const bot of pool.get_assigned_bots()) {
+    if (bot.session_id === session_id && bot.channel_id) {
+      return bot.channel_id;
+    }
+  }
+  return null;
+}
+
+/** Convenience boolean. */
+export function is_discord_bound(session_id: string, pool: BotPool | null): boolean {
+  return resolve_bound_channel(session_id, pool) !== null;
+}
+
+// ── Heartbeat generation ──
+
+/**
+ * Ask Haiku for a one-line "what just happened" summary. Mirrors the shape of
+ * `extract_session_learnings` in hooks.ts but bounded tighter — Stop hooks
+ * have a 10s budget and Haiku takes 2–5s, so we cap at 6s and bail gracefully.
+ */
+export async function generate_heartbeat(turn: TurnSummary): Promise<string> {
+  const tool_list = turn.tool_summary || "(no tools)";
+  const prompt = [
+    "You are summarizing what an autonomous coding agent just did in one short line.",
+    "The agent finished a turn without sending any user-facing text.",
+    "",
+    `Tools invoked this turn: ${tool_list}`,
+    "",
+    "Write ONE sentence (max 15 words) describing what's happening, in present continuous tense.",
+    'Examples: "Running tests on the new endpoint." / "Refactoring the pool resume logic." /',
+    '"Investigating the failing CI check on PR #42."',
+    "",
+    "Reply with ONLY the sentence, no preamble, no quotes.",
+  ].join("\n");
+
+  const claude_bin = process.env.CLAUDE_BIN ?? "claude";
+  const { stdout } = await exec(
+    claude_bin,
+    ["-p", "--model", "haiku", "--no-session-persistence", "--print", prompt],
+    { timeout: 6_000 },
+  );
+  return stdout.trim();
+}
+
+// ── Orchestrator ──
+
+/**
+ * Heartbeat prefix — visually distinguishes daemon-authored heartbeats from
+ * agent messages. Italic + bracket tag. Helen can refine.
+ */
+export const HEARTBEAT_PREFIX = "*[heartbeat]* ";
+
+/** Reminder text shown to the agent on the blocked path (failure mode a). */
+export const REPLY_REMINDER =
+  "You produced assistant text but did not route it to Discord. Call the `reply` tool now with the user-facing portion of your last response. The user only sees what `reply` sends.";
+
+/**
+ * Evaluate a Stop hook fire. Returns the response payload the HTTP handler
+ * should send back to the hook script.
+ *
+ * Side effects:
+ *   - On heartbeat path: posts a message to the bound Discord channel.
+ *   - On any failure: logs + Sentry breadcrumb. NEVER throws — the hook
+ *     budget is tight and a thrown error here would fail-closed against
+ *     unrelated agent work.
+ */
+export async function evaluate_stop(
+  args: { session_id: string; working_dir: string },
+  deps: EvaluateStopDeps,
+): Promise<StopHookResponse> {
+  const { session_id, working_dir } = args;
+  const now_fn = deps.now ?? Date.now;
+  const read_turn = deps.read_turn ?? read_last_assistant_turn;
+  const make_heartbeat = deps.make_heartbeat ?? generate_heartbeat;
+
+  // Step 1: Discord-bound check is cheap — do it first to short-circuit
+  // pass-through cases (subagents, CLI agents, queue tasks).
+  const channel_id = resolve_bound_channel(session_id, deps.pool);
+  if (!channel_id) {
+    return { ok: true };
+  }
+
+  // Step 2: parse the last assistant turn from the JSONL tail.
+  let turn: TurnSummary;
+  try {
+    turn = await read_turn(working_dir, session_id);
+  } catch (err) {
+    // Parsing failed — fail open. Don't block the agent on a transcript bug.
+    console.warn(
+      `[reply-enforce] transcript read failed for ${session_id.slice(0, 8)}: ${String(err)}`,
+    );
+    sentry.addBreadcrumb({
+      category: "reply-enforce",
+      level: "warning",
+      message: "transcript read failed",
+      data: { session_id: session_id.slice(0, 8), err: String(err) },
+    });
+    return { ok: true };
+  }
+
+  // Belt-and-suspenders: if the transcript flagged this as a sidechain, treat
+  // as not bound. (The pool check above should already exclude subagents,
+  // since their session ids aren't in the assignment map.)
+  if (turn.is_sidechain) {
+    return { ok: true };
+  }
+
+  if (!turn.found) {
+    // No transcript on disk yet (or empty). Pass through — there is nothing
+    // to enforce against.
+    return { ok: true };
+  }
+
+  // Step 3: decide.
+  if (turn.produced_text && !turn.called_reply) {
+    // Failure mode (a): hard enforce.
+    return { ok: true, block: true, reminder: REPLY_REMINDER };
+  }
+
+  if (!turn.produced_text && !turn.called_reply) {
+    // Failure mode (b): heartbeat. Cooldown to prevent spam.
+    const now = now_fn();
+    if (in_cooldown(channel_id, now)) {
+      return { ok: true };
+    }
+
+    try {
+      const summary = await make_heartbeat(turn);
+      const trimmed = summary.trim();
+      if (trimmed && deps.discord) {
+        await deps.discord.send(channel_id, `${HEARTBEAT_PREFIX}${trimmed}`);
+        mark_cooldown(channel_id, now);
+      }
+    } catch (err) {
+      // Haiku timeout / Discord send error — log, don't block.
+      console.warn(
+        `[reply-enforce] heartbeat skipped for ${session_id.slice(0, 8)}: ${String(err)}`,
+      );
+      sentry.addBreadcrumb({
+        category: "reply-enforce",
+        level: "warning",
+        message: "heartbeat skipped",
+        data: { session_id: session_id.slice(0, 8), err: String(err) },
+      });
+    }
+
+    return { ok: true };
+  }
+
+  // produced_text + called_reply → normal pass-through.
+  // !produced_text + called_reply → mid-turn streaming reply, also pass-through.
+  return { ok: true };
+}

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -20,6 +20,7 @@ import type { PRWatchStore } from "./pr-watches.js";
 import { QueueFullError } from "./queue.js";
 import type { TaskQueue, TaskSubmission } from "./queue.js";
 import type { EntityRegistry } from "./registry.js";
+import { evaluate_stop } from "./reply-enforcement.js";
 import {
   format_sentry_alert,
   format_sentry_alert_minimal,
@@ -430,10 +431,36 @@ async function build_sentry_alert_message(opts: {
 
 // ── Hook endpoints ──
 
-const handle_stop_hook: RouteHandler = async (req, res) => {
+const handle_stop_hook: RouteHandler = async (req, res, ctx) => {
   const body = await read_body(req);
   console.log("[hooks] Stop hook triggered:", body.slice(0, 200));
-  json_response(res, 200, { ok: true });
+
+  let parsed: { session_id?: string; working_dir?: string };
+  try {
+    parsed = JSON.parse(body) as { session_id?: string; working_dir?: string };
+  } catch {
+    json_response(res, 200, { ok: true });
+    return;
+  }
+
+  const session_id = typeof parsed.session_id === "string" ? parsed.session_id : "";
+  const working_dir = typeof parsed.working_dir === "string" ? parsed.working_dir : "";
+  if (!session_id || !working_dir) {
+    json_response(res, 200, { ok: true });
+    return;
+  }
+
+  try {
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      { pool: ctx.pool, discord: ctx.discord },
+    );
+    json_response(res, 200, result);
+  } catch (err) {
+    // Hook budget is tight; never bubble — fail open.
+    console.warn(`[hooks] stop-hook evaluator threw: ${String(err)}`);
+    json_response(res, 200, { ok: true });
+  }
 };
 
 // ── Task routes ──


### PR DESCRIPTION
## Summary

Closes #39.

Adds daemon-level enforcement for the two failure modes of Discord-routed agent sessions:

- **Failure mode (a) — text-with-no-reply.** Agent produced assistant text but didn't call the Discord `reply` tool. Daemon returns `{block: true, reminder}`; the Stop hook script exits 2 with the reminder on stderr, forcing the agent to route on the next turn.
- **Failure mode (b) — silent turn.** Tool-only turn on a Discord-bound session. Daemon reads the transcript tail, asks Haiku for a one-line summary, posts it as a daemon-styled heartbeat (`*[heartbeat]* ...`) to the bound channel. Per-channel cooldown (60s) prevents spam.

Pass-through cases (non-Discord-bound sessions, subagent sidechains, transcripts not yet flushed, mid-turn streaming replies) never block and never heartbeat.

## Implementation

- `packages/daemon/src/reply-enforcement.ts` — new module with `parse_last_assistant_turn`, `read_last_assistant_turn` (with bounded retry loop ~250ms cap to mitigate the JSONL flush race), `resolve_bound_channel` / `is_discord_bound` (queries pool's assigned-bot session_ids), `generate_heartbeat` (Haiku call mirroring `extract_session_learnings`, capped at 6s), `evaluate_stop` orchestrator. Module-level cooldown map keyed by `channel_id`.
- `packages/daemon/src/server.ts` — `handle_stop_hook` delegates to `evaluate_stop`, never bubbles errors past HTTP (fail-open semantics).
- `packages/cli/src/commands/init/generate.ts` — Stop hook command inspects `.block` field via `jq`, exits 2 on block, exits 0 on every other path (including curl/jq failure → daemon unreachable must never wedge an agent).

## Risks addressed

- **Transcript-tail flush race** — bounded retry loop with size-settle.
- **Hook latency budget (10s)** — Haiku capped at 6s, errors swallowed.
- **Subagent boundaries** — pool check excludes them naturally (sidechain session_ids never in the assignment map); transcript `isSidechain` flag is a belt-and-suspenders second check.
- **Daemon unreachable / wedged** — hook script exits 0 on any non-block response or curl failure.

## Live settings.json

The CLI template is updated for new installs. The live `~/.claude/settings.json` requires a manual update — the running agent's harness rejected the self-edit (correctly). Hunter to apply once the PR merges. Documented in the daily log + the entity MEMORY.md drift note carries forward.

## Test plan

- [x] 28 unit tests in `packages/daemon/src/__tests__/reply-enforcement.test.ts` covering every acceptance-criteria checkbox: text+reply pass, text-no-reply bound→block, text-no-reply unbound→pass, silent bound→heartbeat, cooldown debounce, silent unbound→no-op, sidechain pass-through, transcript-not-found pass-through, transcript-error fail-open, Haiku-error fail-open + no cooldown burn, mid-turn streaming reply pass-through, null pool pass-through.
- [x] Filesystem-level test for the JSONL flush race (writes the file ~25ms into the call, verifies the retry loop catches it).
- [x] All 1186 pre-existing daemon tests still pass under `scripts/run-tests-isolated.sh`.
- [x] Typecheck clean for daemon and CLI.
- [ ] Manual smoke (post-merge): agent intentionally skips `reply` after writing text → reminder lands, agent re-routes next turn.
- [ ] Manual smoke (post-merge): agent runs a long background task without text → heartbeat lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)