### PR TITLE
fix(pool): include entity #alerts channel in outbound allowlist (closes #40)

### DIFF
--- a/docs/memory/project_design_decisions.md
+++ b/docs/memory/project_design_decisions.md
@@ -41,6 +41,8 @@ Four layers, hardest to softest:
 
 **One bot = one session = one channel.** Each pool bot runs as its own Claude Code session via the native Discord channel plugin. Separate context windows, no cross-contamination, no latency. Channel scoping uses the `groups` field in `access.json` which accepts **channel IDs** (not server IDs) to restrict which channel the bot listens to.
 
+**Outbound allowlist enrichment for #alerts (#40).** The Discord plugin gates *outbound* `reply` calls on the same `groups` map it uses for inbound. Pool bots therefore also need their entity's `#alerts` channel listed — otherwise escalations and notifications fail with "channel is not allowlisted." The daemon adds this entry automatically when reconciling `access.json`, with `requireMention: true` so the bot doesn't accidentally consume alert posts as commands. `#alerts` remains broadcast-only output to Hunter, never an agent input surface.
+
 **LRU pool management.** When all pool bots are assigned and a new channel needs one:
 1. Find the least recently active bot
 2. Park its session (kill tmux, preserve session ID for later `--resume`)

--- a/packages/daemon/src/__tests__/pool-access-control.test.ts
+++ b/packages/daemon/src/__tests__/pool-access-control.test.ts
@@ -2,10 +2,11 @@ import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
-import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { BotPool } from "../pool.js";
+import type { EntityRegistry } from "../registry.js";
 
 /** Create a config with the given discord.user_id. */
 function make_config(user_id?: string): LobsterFarmConfig {
@@ -22,16 +23,63 @@ function make_config_no_discord(): LobsterFarmConfig {
   });
 }
 
+/** Build a minimal EntityConfig stub for registry mocking. */
+function make_entity(id: string, channels: Array<{ type: string; id: string }>): EntityConfig {
+  return {
+    entity: {
+      id,
+      name: id,
+      description: "",
+      status: "active",
+      blueprint: "software",
+      pr_lifecycle: "v1",
+      repos: [],
+      accounts: { github: { user: "test" } },
+      channels: {
+        category_id: "cat-1",
+        list: channels.map((c) => ({
+          type: c.type,
+          id: c.id,
+          purpose: "",
+        })),
+      },
+      memory: { path: "/tmp", auto_extract: false },
+      secrets: { vault: "1password", vault_name: `entity-${id}` },
+    },
+  } as unknown as EntityConfig;
+}
+
+/** Build a fake EntityRegistry that returns our stubbed entities. */
+function make_registry(entities: Record<string, EntityConfig>): EntityRegistry {
+  return {
+    get: (id: string) => entities[id],
+    get_all: () => Object.values(entities),
+    get_active: () => Object.values(entities),
+    count: () => Object.keys(entities).length,
+    load_all: async () => {},
+  } as unknown as EntityRegistry;
+}
+
 /**
- * Test subclass that exposes write_access_json for direct testing.
- * The real method is private, so we call it via bracket notation.
+ * Test subclass that exposes write_access_json for direct testing and
+ * lets tests inject a fake registry. The real method is private, so we
+ * call it via bracket notation.
  */
 class TestBotPool extends BotPool {
-  async test_write_access_json(state_dir: string, channel_id: string | null): Promise<void> {
-    // Call the private method via bracket notation
+  set_registry(registry: EntityRegistry | null): void {
+    (this as unknown as { registry: EntityRegistry | null }).registry = registry;
+  }
+
+  async test_write_access_json(
+    state_dir: string,
+    channel_id: string | null,
+    entity_id: string | null = null,
+  ): Promise<void> {
     return (
-      this as unknown as { write_access_json: (d: string, c: string | null) => Promise<void> }
-    ).write_access_json(state_dir, channel_id);
+      this as unknown as {
+        write_access_json: (d: string, c: string | null, e: string | null) => Promise<void>;
+      }
+    ).write_access_json(state_dir, channel_id, entity_id);
   }
 }
 
@@ -114,5 +162,108 @@ describe("pool bot access control", () => {
 
     const content = JSON.parse(await readFile(join(tmp_dir, "access.json"), "utf-8"));
     expect(content.groups).toEqual({});
+  });
+
+  // ── #40: alerts channel outbound allowlist enrichment ──
+
+  it("includes the entity's #alerts channel in groups when entity_id is provided (#40)", async () => {
+    const config = make_config("111");
+    const pool = new TestBotPool(config);
+    pool.set_registry(
+      make_registry({
+        healthydogs: make_entity("healthydogs", [
+          { type: "general", id: "general-chan" },
+          { type: "alerts", id: "alerts-chan" },
+          { type: "work_room", id: "wr-chan" },
+        ]),
+      }),
+    );
+
+    await pool.test_write_access_json(tmp_dir, "wr-chan", "healthydogs");
+
+    const content = JSON.parse(await readFile(join(tmp_dir, "access.json"), "utf-8"));
+    // Inbound channel: requireMention false (normal listening)
+    expect(content.groups["wr-chan"]).toEqual({
+      requireMention: false,
+      allowFrom: [],
+    });
+    // Alerts channel: outbound-only — requireMention true so we don't consume
+    // alert posts as commands
+    expect(content.groups["alerts-chan"]).toEqual({
+      requireMention: true,
+      allowFrom: [],
+    });
+  });
+
+  it("does not duplicate an entry when the bot is bound directly to its #alerts channel", async () => {
+    const config = make_config("111");
+    const pool = new TestBotPool(config);
+    pool.set_registry(
+      make_registry({
+        healthydogs: make_entity("healthydogs", [{ type: "alerts", id: "alerts-chan" }]),
+      }),
+    );
+
+    await pool.test_write_access_json(tmp_dir, "alerts-chan", "healthydogs");
+
+    const content = JSON.parse(await readFile(join(tmp_dir, "access.json"), "utf-8"));
+    // The inbound entry wins — keep requireMention: false so the bot listens
+    expect(content.groups["alerts-chan"]).toEqual({
+      requireMention: false,
+      allowFrom: [],
+    });
+    expect(Object.keys(content.groups)).toEqual(["alerts-chan"]);
+  });
+
+  it("omits the alerts entry when the entity has no alerts channel configured", async () => {
+    const config = make_config("111");
+    const pool = new TestBotPool(config);
+    pool.set_registry(
+      make_registry({
+        healthydogs: make_entity("healthydogs", [{ type: "general", id: "general-chan" }]),
+      }),
+    );
+
+    await pool.test_write_access_json(tmp_dir, "general-chan", "healthydogs");
+
+    const content = JSON.parse(await readFile(join(tmp_dir, "access.json"), "utf-8"));
+    expect(Object.keys(content.groups)).toEqual(["general-chan"]);
+  });
+
+  it("omits the alerts entry when the entity_id is unknown to the registry", async () => {
+    const config = make_config("111");
+    const pool = new TestBotPool(config);
+    pool.set_registry(make_registry({}));
+
+    await pool.test_write_access_json(tmp_dir, "general-chan", "healthydogs");
+
+    const content = JSON.parse(await readFile(join(tmp_dir, "access.json"), "utf-8"));
+    expect(Object.keys(content.groups)).toEqual(["general-chan"]);
+  });
+
+  it("omits the alerts entry when entity_id is null (free or parked bot)", async () => {
+    const config = make_config("111");
+    const pool = new TestBotPool(config);
+    pool.set_registry(
+      make_registry({
+        healthydogs: make_entity("healthydogs", [{ type: "alerts", id: "alerts-chan" }]),
+      }),
+    );
+
+    await pool.test_write_access_json(tmp_dir, null, null);
+
+    const content = JSON.parse(await readFile(join(tmp_dir, "access.json"), "utf-8"));
+    expect(content.groups).toEqual({});
+  });
+
+  it("safely handles a missing registry (lookup returns null)", async () => {
+    const config = make_config("111");
+    const pool = new TestBotPool(config);
+    // No registry injected — resolve_alerts_channel_id should short-circuit
+
+    await pool.test_write_access_json(tmp_dir, "chan-1", "healthydogs");
+
+    const content = JSON.parse(await readFile(join(tmp_dir, "access.json"), "utf-8"));
+    expect(Object.keys(content.groups)).toEqual(["chan-1"]);
   });
 });

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -719,12 +719,17 @@ export class BotPool extends EventEmitter {
     // assignments. access.json files may be stale from a previous run (e.g., a bot that
     // was reassigned or freed but whose tmux survived the restart). Rewriting them all
     // ensures the Discord plugin only listens to channels the daemon actually assigned.
+    //
+    // We also pass `bot.entity_id` so write_access_json can enrich the outbound
+    // allowlist with the entity's #alerts channel (#40). For free/parked bots
+    // this is null and no alerts entry is written.
     for (const bot of this.bots) {
       // Only assigned bots (with live tmux) should listen on their channel.
       // Parked and free bots get empty access.json — their channel claim is
       // preserved in memory/pool-state.json for resume, not in access.json.
       const expected_channel = bot.state === "assigned" ? bot.channel_id : null;
-      await this.write_access_json(bot.state_dir, expected_channel);
+      const expected_entity = bot.state === "assigned" ? bot.entity_id : null;
+      await this.write_access_json(bot.state_dir, expected_channel, expected_entity);
     }
     console.log(`[pool] Reconciled access.json for ${String(this.bots.length)} bots`);
 
@@ -801,8 +806,10 @@ export class BotPool extends EventEmitter {
         }
         this.kill_tmux(bot.tmux_session);
 
-        // Write access.json so the Discord plugin listens on this channel
-        await this.write_access_json(bot.state_dir, candidate.channel_id);
+        // Write access.json so the Discord plugin listens on this channel.
+        // Pass entity_id so the entity's #alerts channel is also added to the
+        // outbound allowlist (#40).
+        await this.write_access_json(bot.state_dir, candidate.channel_id, candidate.entity_id);
 
         // Set Discord nickname and profile avatar to match the archetype
         await this.set_bot_nickname(bot, candidate.archetype);
@@ -1085,8 +1092,9 @@ export class BotPool extends EventEmitter {
       // Kill any existing tmux session
       this.kill_tmux(bot.tmux_session);
 
-      // Update access.json with the channel ID
-      await this.write_access_json(bot.state_dir, channel_id);
+      // Update access.json with the channel ID. Pass entity_id so the
+      // entity's #alerts channel is also added to the outbound allowlist (#40).
+      await this.write_access_json(bot.state_dir, channel_id, entity_id);
 
       // Set Discord nickname and profile avatar to match the archetype
       await this.set_bot_nickname(bot, archetype);
@@ -1721,9 +1729,11 @@ export class BotPool extends EventEmitter {
         );
       }
 
-      // Write access.json so the Discord plugin listens on this channel
+      // Write access.json so the Discord plugin listens on this channel.
+      // Include entity_id so the entity's #alerts channel is added to the
+      // outbound allowlist (#40).
       if (channel_id) {
-        await this.write_access_json(bot.state_dir, channel_id);
+        await this.write_access_json(bot.state_dir, channel_id, entity_id);
       }
 
       // Restart tmux — use --resume if we have a verified session_id
@@ -2167,10 +2177,56 @@ export class BotPool extends EventEmitter {
 
   // ── Internal ──
 
-  private async write_access_json(state_dir: string, channel_id: string | null): Promise<void> {
+  /**
+   * Resolve the alerts channel ID for an entity, if any.
+   * Returns null when the registry isn't ready, the entity isn't registered,
+   * or the entity has no `type: "alerts"` channel configured.
+   *
+   * Pool bots are assigned to a single inbound channel (general or work_room),
+   * but agents are expected to *post* to their entity's #alerts channel for
+   * approvals, blockers, and incident notifications. The Discord plugin only
+   * permits outbound `reply` to channels present in `access.json.groups`, so
+   * we add the alerts channel as an outbound-only entry (see `write_access_json`).
+   */
+  private resolve_alerts_channel_id(entity_id: string | null): string | null {
+    if (!entity_id || !this.registry) return null;
+    const entity_config = this.registry.get(entity_id);
+    if (!entity_config) return null;
+    const alerts_channel = entity_config.entity.channels.list.find((ch) => ch.type === "alerts");
+    return alerts_channel?.id ?? null;
+  }
+
+  /**
+   * Write the Discord plugin's access.json for a pool bot.
+   *
+   * The plugin enforces a two-way allowlist:
+   *   - Inbound: messages are delivered only from channels in `groups`, gated
+   *     by `requireMention` (when true, only @mentions trigger the agent).
+   *   - Outbound: `reply` and other send tools only target channels in `groups`.
+   *
+   * Pool bots are assigned to ONE inbound channel (general or work_room). They
+   * also need OUTBOUND access to their entity's #alerts channel so agents can
+   * escalate. We add the alerts channel with `requireMention: true` so the bot
+   * doesn't accidentally consume alert posts as commands — alerts are meant to
+   * be broadcast-only output to Hunter, not an agent input surface. See #40.
+   */
+  private async write_access_json(
+    state_dir: string,
+    channel_id: string | null,
+    entity_id: string | null = null,
+  ): Promise<void> {
     const groups: Record<string, { requireMention: boolean; allowFrom: string[] }> = {};
     if (channel_id) {
       groups[channel_id] = { requireMention: false, allowFrom: [] };
+    }
+
+    // Always include the entity's #alerts channel for outbound posts when we
+    // can resolve it. Guarded with `requireMention: true` so the channel is
+    // strictly an output destination — incoming traffic without an explicit
+    // mention is ignored, preserving the broadcast-only semantics.
+    const alerts_channel_id = this.resolve_alerts_channel_id(entity_id);
+    if (alerts_channel_id && alerts_channel_id !== channel_id) {
+      groups[alerts_channel_id] = { requireMention: true, allowFrom: [] };
     }
 
     // The owner's Discord user ID controls who can DM pool bots.


### PR DESCRIPTION
## Summary

Pool bots can now post to their entity's `#alerts` channel. Closes #40.

The Discord plugin enforces outbound message gating on `access.json.groups` — channels not present there raise `"channel <id> is not allowlisted"`. The daemon was writing **only** the bot's single inbound channel into `groups`, so any agent trying to escalate to `#alerts` (per CLAUDE.md guidance and every escalation skill) was silently rejected. Affected all 8 entities with configured alerts channels.

## Approach chosen

Two options were on the table when this issue was filed:

1. **Pool-level allowlist enrichment** — add the alerts channel to every pool bot's `access.json` during reconciliation. _Selected._
2. **New daemon endpoint** — agents `POST /alerts` to a privileged dispatcher bot.

I picked **#1** because:

| Factor | #1 (this PR) | #2 (new endpoint) |
|---|---|---|
| Code surface | One function (`write_access_json`) + a small registry lookup | New HTTP endpoint, new privileged bot lifecycle, new agent-side calling convention |
| Risk to existing flow | Tiny — additive entries in the `groups` map | Agents currently call the Discord plugin's `reply` tool against the alerts channel ID. Approach 2 forces a migration of every escalation site. |
| Agent contract | Zero change — `reply` to `#alerts` just works | Every persona doc + skill needs rewriting |
| Reconciliation safety | Reconciliation already runs `write_access_json`; the enrichment is automatically reapplied on every restart | Requires maintaining a parallel privileged bot |
| Inbound safety | `requireMention: true` on the alerts entry — bot posts but never consumes alert traffic | N/A |

## Changes

- **`packages/daemon/src/pool.ts`**
  - New `resolve_alerts_channel_id(entity_id)` helper that walks `entity.channels.list` for `type: "alerts"`. Returns `null` when registry/entity/channel is missing — fully optional.
  - `write_access_json(state_dir, channel_id, entity_id?)` now optionally takes an entity ID. When present, the entity's alerts channel is added to `groups` with `requireMention: true` (outbound-only — broadcast semantics preserved). Skipped when the alerts channel equals the inbound channel (no duplicate entry).
  - All assignment + reconciliation call sites pass `bot.entity_id`. Dedup/release/park paths still pass `null` to clear access entirely.

- **`packages/daemon/src/__tests__/pool-access-control.test.ts`** — 6 new test cases:
  - Adds the alerts channel with `requireMention: true` when entity_id is provided
  - Doesn't duplicate when bot is bound directly to its alerts channel
  - Omits when entity has no alerts channel
  - Omits when entity is unknown to the registry
  - Omits when entity_id is null (free/parked bots)
  - Omits when registry isn't initialized

- **`docs/memory/project_design_decisions.md`** — short note documenting the outbound-allowlist behavior, alongside the existing `groups` description.

## Test plan

- [x] `vitest run pool-access-control` — 12/12 passing (6 existing + 6 new)
- [x] `vitest run pool` — 109/109 passing across `pool.test.ts`, `pool-access-control.test.ts`, `pool-persistence.test.ts`, `pool-avatars.test.ts`, `pool-session-confirmation.test.ts`
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] `tsup` build succeeds
- [ ] Post-merge: bounce daemon, verify a test message from a pool-bot agent to HealthyDogs `#alerts` succeeds (was failing pre-fix). Spot-check 1-2 other entities.
- [ ] Post-merge: bounce daemon a second time and re-verify — catches any reconciliation regression. This is the failure mode called out in the issue.

## Notes

- Pre-existing flake in `session-start-hook.test.ts` when run in the full suite due to coalition inheritance — already documented in commit `a1391f5` and unrelated to this change. Test passes in isolation and with the `run-tests-isolated.sh` wrapper.
- Karim is mid-rollout on `#39` (production deployment) so daemon bounce + verification will happen after his rollout completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)