### PR TITLE
feat(dna): autonomous build-review-merge loop as default

### DIFF
--- a/config/claude/skills/README.md
+++ b/config/claude/skills/README.md
@@ -20,4 +20,5 @@ Skills fall into three categories:
 - `discord-guideline/` -- Discord server management. Channel scaffolding, bot architecture, webhook patterns.
 - `tech-standards/` -- Architectural best practices and team technology standards. Shared decision guide for planners, builders, and reviewers.
 - `pr-review-merge/` -- SOP for the PR review, feedback, and merge workflow.
+- `feature-lifecycle/` -- SOP for how features move from idea to shipped, including the autonomous build-review-merge loop.
 - `entity-scaffold/` -- SOP for standing up a new entity from a blueprint.

--- a/config/claude/skills/coding-dna/SKILL.md
+++ b/config/claude/skills/coding-dna/SKILL.md
@@ -781,6 +781,26 @@ All LobsterFarm repos use husky + lint-staged. Every commit automatically runs B
 
 As a belt-and-suspenders habit: run `pnpm lint` before committing to catch issues early. But the hook is the real safety net.
 
+### Self-smoke-test before every push (autonomous loop)
+
+When you're operating inside the autonomous build-review-merge loop (Ben on an assigned issue, on a feature branch, with the Reviewer waiting on the other side of the PR), **run the project's test suite locally before every push**. The Reviewer's full E2E pass is expensive — don't burn a review cycle on a known-broken state.
+
+```bash
+# Canonical for this repo (and any repo with the wrapper):
+scripts/run-tests-isolated.sh pnpm -r test
+
+# Per-package fallback when the wrapper isn't available:
+pnpm --filter <package> test
+```
+
+The smoke test is the gate, not the loop:
+
+- **Smoke passes** → push, let the Reviewer take it from there
+- **Smoke fails** → fix locally, re-run, only push when green
+- **Test infra fails** (wrapper crashes, environment issue, unrelated flake you've confirmed is pre-existing) → push with a note in the PR thread describing what failed and why you believe it's not your change. Don't silently push past a red suite.
+
+This is non-negotiable in the autonomous loop. Outside the loop (manual exploratory work, drafts you're not asking the Reviewer to look at yet) the rule relaxes to "test before you ask for review."
+
 ### Environment Separation
 
 | Environment | Branch | Database | Secrets | Deployment |

--- a/config/claude/skills/feature-lifecycle/SKILL.md
+++ b/config/claude/skills/feature-lifecycle/SKILL.md
@@ -65,6 +65,8 @@ This is the default path from PR-open to merged. The full mechanics — cycle co
 
 **Trigger:** the daemon's PR poll detects the open PR and spawns the Reviewer (existing behavior, no change).
 
+> **Current state (as of this writing):** the daemon already auto-spawns the Reviewer on PR-open. It does **not** yet auto-spawn Ben for fix cycles after a Changes Requested verdict — that piece is pending daemon implementation. Until it ships, fix cycles still require manual orchestration via Tidus (or a direct `!lf swap ben` in the relevant work room). The DNA below describes the intended steady state; the cycle-2 pickup is the gap to be aware of.
+
 **The loop:**
 
 ```
@@ -118,7 +120,7 @@ For visual work, Tidus can spawn Helen (designer) as a subagent, or you can ask 
 
 **Direct agent access via swap.** If you want to riff directly with Helen on design or Ben on implementation, use `!lf swap helen` or `!lf swap ben` in a work room. The daemon swaps the pool bot's archetype.
 
-**Reviewer is independent.** The Reviewer agent is spawned fresh per review iteration by the daemon's PR poll, not by Tidus. Fresh eyes every time, no memory of the last cycle. Cycle state is read from `gh pr view --json reviews`, not carried in agent memory.
+**Reviewer is independent.** The Reviewer agent is spawned fresh per review iteration by the daemon's PR poll, not by Tidus. Fresh eyes every time, no memory of the last cycle. Cycle state is read from `gh pr view` (`--json reviews` in multi-dev repos, `--json comments` in single-dev repos — see `pr-review-merge` for the exact queries), not carried in agent memory.
 
 ## Agent Behavior
 

--- a/config/claude/skills/feature-lifecycle/SKILL.md
+++ b/config/claude/skills/feature-lifecycle/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: feature-lifecycle
+description: >
+  The feature lifecycle — how features move from idea to shipped.
+  Auto-loads when creating features, planning work, managing the build loop,
+  or understanding how work flows through the system.
+---
+
+# Feature Lifecycle SOP
+
+_How a feature moves from idea to shipped code in LobsterFarm._
+
+---
+
+## Overview
+
+The planner (Tidus) is the orchestrator for each entity. Features start as conversations — you riff with Tidus in #general or a work room. When a feature is ready to build, Tidus creates the GitHub issue, hands off to Ben (builder) as a subagent, and the team runs the build → review → fix → E2E → merge loop autonomously by default. You stay in Discord for everything — the planning conversation, the staging gate (when applicable), and any escalation.
+
+```
+Riff with Tidus → spec ready → GitHub issue created → Ben builds (subagent) →
+  PR opened → autonomous build-review-merge loop → shipped
+```
+
+The loop is hands-off by default. Hunter is pulled in only at the staging gate (for repos with `origin/staging`) or via the standing escalation rules — not on every feature, not on every cycle.
+
+## How It Works
+
+### 1. Discovery (in Discord)
+
+You describe what you want in #general or a work room. Tidus does socratic discovery — asks questions, proposes approaches, scopes the work. This is a conversation, not a form to fill out.
+
+When the spec is solid, Tidus creates a GitHub issue as the record. The issue is the OUTPUT of planning, not the input.
+
+### 2. Approval (legacy / optional)
+
+The autonomous loop is the default. The pre-PR approval gate described here is **legacy** — kept for situations where you genuinely want a human-in-the-loop preview before code goes up for review.
+
+**Use the legacy gate only when:**
+- The work is **visual** (UI, design, brand) and you want to see a screenshot or live preview before the PR opens
+- The spec explicitly opts in via a `verification: user` declaration in the GitHub issue (see `coding-dna` → "PR Workflow")
+- You're testing a new pattern and want a checkpoint mid-build
+
+**Otherwise, skip approval entirely.** Tidus hands the issue to Ben, Ben opens the PR, and the autonomous loop takes over from there. The Reviewer's verdict is the quality gate; the staging-test step (when applicable) is the product gate.
+
+If the legacy gate is in use:
+- For visual work: Tidus or Ben shows a screenshot/preview in the work room and waits for "looks good" before opening the PR
+- For `verification: user`: Ben pushes the branch, posts test instructions, and waits per the `coding-dna` PR Workflow rules
+
+### 3. Build (subagent)
+
+Tidus spawns Ben as a subagent within his session. Ben inherits full context from the planning conversation — no information loss. Ben:
+- Creates a feature branch
+- Implements the feature following the spec
+- Writes tests
+- **Self-smoke-tests before every push** (per `coding-dna` → "Self-smoke-test before every push") — don't burn a Reviewer cycle on a known-broken state
+- Runs `/simplify` to clean up
+- Commits and pushes
+- Creates a PR with `Closes #{issue}` in the body
+
+Tidus reports the result back to you in Discord.
+
+### 4. The autonomous loop
+
+This is the default path from PR-open to merged. The full mechanics — cycle counting, E2E gating, branch-aware terminal step — live in `pr-review-merge`. This section is the lifecycle-level summary.
+
+**Trigger:** the daemon's PR poll detects the open PR and spawns the Reviewer (existing behavior, no change).
+
+**The loop:**
+
+```
+PR opened
+  ↓
+Reviewer reviews (cycle 1, 2, or 3)
+  ├─ Spec gap?      → pause, ping Tidus in #alerts (does NOT count as cycle)
+  ├─ Changes needed → Ben fixes + smoke-tests + pushes → cycle++
+  └─ Approved       → break to E2E
+  ↓
+4th cycle would trigger? → escalate to Hunter in #alerts, stop
+  ↓
+Reviewer runs full E2E (final iteration only)
+  ├─ Blocking finding → flip to Changes Requested, counts as cycle (subject to cap)
+  └─ Clean           → final approval → terminal step
+  ↓
+Terminal step (branch-aware):
+  ├─ origin/staging exists:
+  │    1. Squash-merge to staging
+  │    2. Post test plan in #work-log AND as PR comment
+  │    3. Ping Hunter in #alerts
+  │    4. On Hunter's ✅ → fast-forward staging → main
+  │
+  └─ Only origin/main:
+       Squash-merge straight to main, post completion in #work-log
+```
+
+**Loop cap (3 cycles).** The Reviewer counts prior verdicts on the PR. If a 4th iteration would trigger, escalate to Hunter in #alerts instead — PR link, summary of disagreement, both positions, recommended path forward. Don't loop past the cap.
+
+**E2E happens once.** Not on every iteration. The deep pass (playwright + access-tool exercise of the feature) runs at the moment the Reviewer would otherwise post the final Approved verdict. If E2E surfaces a blocker, it flips to Changes Requested and counts as a cycle. If clean, the loop terminates.
+
+**Spec-gap pauses don't burn cycles.** When the Reviewer can't tell whether something is a bug (Ben implemented the wrong thing) or a spec gap (the spec didn't say), they apply the heuristic in `review-dna`. Spec gaps pause the loop and ping Tidus in #alerts, not Hunter. The cycle counter is unchanged. When Tidus amends the issue and replies with the clarification, Ben implements against the updated spec and the loop resumes from where it paused.
+
+**Staging gate (when `origin/staging` exists).** After the Reviewer's final approval, the PR is squash-merged into `staging`. A step-by-step test plan goes to **both** #work-log (Discord prose) and the PR (markdown checklist). Hunter is pinged in #alerts. **No auto-promotion** — Hunter's explicit ✅ is the only signal that fast-forwards `staging` → `main`. The 24h re-ping rule applies (per the standing pr-review-merge SOP).
+
+**Main-only repos.** No staging gate. After the Reviewer's final approval, the PR is squash-merged directly into `main` and a completion notice goes to #work-log. Done.
+
+**Escalation rules (unchanged).** Anything touching production, money, emails, auth, security, or anything irreversible still pings Hunter in #alerts regardless of where the loop is. The autonomous default never overrides those rules.
+
+**Hunter can still intervene.** Mid-loop, at any time, for any reason — drop a message in #alerts and the loop pauses. The autonomy is a default, not a lock.
+
+### 5. Design (when needed)
+
+For visual work, Tidus can spawn Helen (designer) as a subagent, or you can ask to talk to Helen directly via `!lf swap helen`. Helen creates design artifacts — brand kits, component libraries, UI prototypes. Swap back to Tidus when done.
+
+## Agent Model
+
+**Tidus is the front door for each entity.** One Tidus session per entity #general channel, always available. You riff with Tidus, Tidus delegates.
+
+**Subagents, not phase cycling.** Tidus spawns Ben, Helen, or Karim as subagents within his session. No pool bot cycling, no cold starts, no context loss. The subagent inherits Tidus's full conversation context.
+
+**Direct agent access via swap.** If you want to riff directly with Helen on design or Ben on implementation, use `!lf swap helen` or `!lf swap ben` in a work room. The daemon swaps the pool bot's archetype.
+
+**Reviewer is independent.** The Reviewer agent is spawned fresh per review iteration by the daemon's PR poll, not by Tidus. Fresh eyes every time, no memory of the last cycle. Cycle state is read from `gh pr view --json reviews`, not carried in agent memory.
+
+## Agent Behavior
+
+**Agents are collaborators, not task executors.** During any phase, agents should surface discoveries that could affect decisions. Plans drift during implementation — new information should be communicated, not suppressed. Ask genuine questions. Don't assume.
+
+**PR bodies must include `Closes #{issue}`.** This auto-closes the GitHub issue on merge. The spec, the PR, and the issue are linked.
+
+**Run `/simplify` before pushing.** Less noise for the reviewer.
+
+**Self-smoke-test before pushing in the loop.** Burning a Reviewer cycle on a red suite is the cheapest mistake to avoid. See `coding-dna` for the canonical command and fallbacks.
+
+**Update daily logs.** After completing work, write to `daily/YYYY-MM-DD.md` with what was done, decisions made, and any open questions.
+
+## Work Room Management
+
+- **Channel topics:** each work room's topic shows current status, updated by the daemon
+  - `🟢 Available`
+  - `🔵 Secret Scanning Hook — Plan`
+  - `🟡 Secret Scanning Hook — Build`
+- **Auto-assignment:** messaging an empty work room auto-assigns a planner
+- **Room release:** when a feature ships, the room status resets to available
+
+## What NOT to Do
+
+- Don't skip the planning conversation for non-trivial features
+- Don't create PRs without `Closes #{issue}` in the body
+- Don't merge PRs outside the review-merge SOP — it tracks PR state, cycle count, and the terminal-step routing
+- Don't loop past 3 cycles — escalate to Hunter
+- Don't auto-promote staging → main — Hunter's ✅ is the only valid signal, no timeout fallback
+- Don't run E2E on every iteration — it's the final-step gate, not a per-cycle tax
+- Don't suppress discoveries — if you learned something that matters, say it

--- a/config/claude/skills/pr-review-merge/SKILL.md
+++ b/config/claude/skills/pr-review-merge/SKILL.md
@@ -17,10 +17,13 @@ _How pull requests get reviewed, fixed, and merged in LobsterFarm._
 Any PR on any entity repo triggers this SOP — whether from a planned feature, a manual push, or an external contributor.
 
 ```
-PR opened → Review → Changes needed? → Fix → Re-review → Merge
+PR opened → Review → Changes needed? → Fix → Re-review → E2E → Merge
                          │                        ↑
                          └── Loop until clean ─────┘
+                            (cap: 3 cycles)
 ```
+
+The full loop runs autonomously by default. Hunter is pulled in only at the staging gate (when `origin/staging` exists) or via the standing escalation rules (production, money, auth, irreversible, security). The cycle cap is hard at 3 — a 4th iteration triggers an escalation instead of another round.
 
 ## Trigger
 
@@ -39,34 +42,125 @@ When a new or updated PR is found that isn't already being processed, the daemon
 Spawn a reviewer agent scoped to the PR.
 
 The reviewer:
-- Loads `review-dna` for our review standards (priority order, comment format, frontend criteria, CI awareness)
+- Loads `review-dna` for our review standards (priority order, comment format, frontend criteria, CI awareness, E2E classification, spec-gap heuristic)
+- **Counts prior review cycles** via `gh pr view <n> --json reviews` before starting. Each prior `Reviewer`-authored review (or findings comment with a `Verdict:` line) is a cycle.
 - Runs `/ultrareview` (Claude Code's parallel multi-agent PR review) for comprehensive analysis
 - Posts the review on the PR via `gh`
 - Verdict: **Approved** or **Changes Requested** — never ambiguous
 
-**Escalation:** If the reviewer has questions about intent or requirements that can't be answered from the spec, escalate to #alerts and wait for a response before completing the review.
+**Cycle cap (hard limit: 3):**
+
+```bash
+gh pr view <n> --json reviews --jq '[.reviews[] | select(.author.login == "<reviewer-login>")] | length'
+```
+
+- `0` prior cycles → this is cycle 1, proceed normally
+- `1` prior → cycle 2, proceed normally
+- `2` prior → cycle 3, this is the last allowed Changes Requested round; if it would request changes, the next iteration will escalate
+- `3` prior → **do not run another review round.** Post an escalation to #alerts pinging Hunter with: PR link, summary of the disagreement, both positions, recommended path forward. Then stop. Wait for Hunter to break the tie.
+
+**Spec-gap pause does not count as a cycle.** If the reviewer flags a spec gap (per the `review-dna` heuristic) instead of requesting changes, the loop pauses pending Tidus's clarification. The cycle counter is unchanged.
+
+**Self-approval blocker — single-dev repos:** GitHub blocks `gh pr review --approve` on PRs the reviewer authored. In single-committer repos (currently all of LobsterFarm), the Reviewer cannot post a formal Approved review. Instead, post a **findings comment** with the verdict line `**Verdict: Approved**` (or `**Verdict: Changes Requested**`) as the first line. The merge step (4) treats a findings-comment Approved verdict as a valid signal — no formal GitHub approval is required for the autonomous loop to proceed. If a second human committer ever joins and the gh path unblocks, switch back to `gh pr review --approve`.
+
+**Escalation:** If the reviewer has questions about intent or requirements that can't be answered from the spec, follow the spec-gap escalation in `review-dna` (ping Tidus, do not increment cycle). If the question is operational (production, money, auth, etc.), escalate to Hunter in #alerts and wait.
 
 ### 2. Fix (if changes requested)
 
-If the review requests changes, spawn a builder agent (Bob) on the PR branch.
+If the review requests changes, spawn a builder agent (Ben) on the PR branch.
 
-Bob:
+Ben:
 - Reads the review comments
 - Addresses each blocking issue
 - Runs `/simplify` to clean up the code
+- **Self-smoke-tests before pushing** (see `coding-dna` → "Self-smoke-test before every push"). Canonical command for this repo: `scripts/run-tests-isolated.sh pnpm -r test`. Do not push a known-broken state — burning a Reviewer cycle on a red suite is the cheapest mistake to avoid.
 - Commits and pushes
 
-**Escalation:** If a review comment requires a design decision or scope change, Bob escalates to #alerts rather than guessing. Wait for input, then continue.
+**Escalation:** If a review comment requires a design decision or scope change, Ben escalates to #alerts rather than guessing. Wait for input, then continue.
 
 ### 3. Re-review
 
-After fixes are pushed, loop back to step 1. A fresh reviewer session — no memory of the previous review. Fresh eyes every time.
+After fixes are pushed, loop back to step 1. A fresh reviewer session — no memory of the previous review. Fresh eyes every time. The cycle counter (read from `gh pr view --json reviews`) tells the new Reviewer where it sits in the loop budget.
 
-The loop continues until the review passes with no blocking issues.
+The loop continues until the Reviewer would post Approved — at which point step 3.5 fires before the merge.
 
-### 4. Merge
+### 3.5. E2E (final iteration only)
 
-When the review is approved:
+This step runs **once**, at the moment the Reviewer would otherwise post the final Approved verdict. It does not run on every loop iteration — that would 3× the cost of every feature for no benefit. The deep pass happens at the end.
+
+The Reviewer:
+
+- Detects the repo's E2E surface:
+  - Playwright: presence of `playwright.config.{ts,js}` or a `playwright/` directory
+  - Other E2E suites: `cypress/`, `e2e/`, or a `pnpm test:e2e` script in `package.json`
+- Runs all E2E suites it found (under `scripts/run-tests-isolated.sh` if available, to avoid the macOS coalition kill)
+- Exercises the feature end-to-end with the available access tools — playwright MCP for browser flows, direct DB queries for persistence checks, `curl` or HTTP clients for API surfaces, whatever the feature actually touches
+- Classifies findings using the E2E rubric in `review-dna` (blocking vs. non-blocking)
+- Posts the E2E results as a single PR comment with both lists clearly headed
+
+**If any blocking finding:** flip the verdict to **Changes Requested**. This counts as a cycle (subject to the cap). Loop back to step 2.
+
+**If no blocking findings:** post the final Approved verdict (findings comment with `**Verdict: Approved**` per the self-approval workaround in step 1). Daemon proceeds to step 4.
+
+**E2E flake policy:** if a test fails, re-run that single test once. If it passes on the second run, treat the first failure as flake — note it in the E2E comment but don't block. If it fails twice, treat it as real and classify per the rubric.
+
+### 4. Merge — terminal step (branch-aware)
+
+The terminal step depends on whether the repo has a staging branch. Detect with:
+
+```bash
+git ls-remote --heads origin staging | grep -q refs/heads/staging
+```
+
+Branch existence is the only signal — no per-repo config flag. If the repo grows a staging branch later, the loop picks it up automatically on the next run.
+
+#### 4a. Repo has `origin/staging` — staging gate applies
+
+1. **Check for conflicts** — `gh pr view {number} --json mergeable`
+2. **Resolve conflicts** if needed (per the rebase rules in 4b below)
+3. **Squash-merge the PR into `staging`:**
+   ```bash
+   gh pr merge {number} --squash --delete-branch --base staging
+   ```
+   (If the PR was opened against `main`, change its base to `staging` first: `gh pr edit {number} --base staging`.)
+4. **Post step-by-step test instructions** in two places — same content, two formats:
+   - **Discord post in #work-log:**
+     ```
+     Feature <title> is on staging. Test plan:
+     1. <first concrete step — open URL, run command, etc.>
+     2. <second step>
+     3. <verify W>
+     ...
+     PR: <link>
+     ```
+   - **PR comment** — same steps, formatted as a markdown checklist Hunter can tick through:
+     ```markdown
+     ## Staging test plan
+     - [ ] <step 1>
+     - [ ] <step 2>
+     - [ ] <verify W>
+     ```
+5. **Post in #alerts** pinging Hunter: "Feature <title> ready for staging test — see #work-log and PR <link>"
+6. **Wait for Hunter's ✅** (or explicit "go" / "ship it" / "hold" message in #alerts). 24h re-ping rule applies — if no response in 24h, re-ping once with the same content.
+7. **Never auto-promote.** No timeout, no default-to-yes. Hunter's explicit signal is the only thing that advances to step 4a.next.
+
+##### 4a.next. Promote staging → main (after Hunter's ✅)
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+git merge --ff-only origin/staging
+git push origin main
+```
+
+Fast-forward only — if `main` has diverged from `staging` and a fast-forward isn't possible, escalate to #alerts with the divergence details and wait. Don't merge with a merge commit, don't rebase, don't force-push.
+
+After the promotion:
+- Notify #work-log: "Feature <title> shipped to main."
+- The GitHub issue auto-closes via the PR's `Closes #<issue>` line (which followed the PR through both merges).
+
+#### 4b. Repo has only `origin/main` — autonomous merge
 
 1. **Check for conflicts** — `gh pr view {number} --json mergeable`
 2. **If clean** — squash merge: `gh pr merge {number} --squash --delete-branch`
@@ -74,7 +168,9 @@ When the review is approved:
    - Attempt a clean rebase: `git rebase main` on the PR branch
    - If the rebase is straightforward (no manual resolution needed), push and merge
    - If the rebase requires decisions (conflicting changes in the same area), escalate to #alerts with the conflict details and wait for guidance
-4. **Post-merge** — notify #general
+4. **Post-merge** — notify #work-log
+
+The autonomous loop completes here for main-only repos. No further steps required.
 
 ## Agent Behavior During Build
 
@@ -97,14 +193,23 @@ This isn't about asking permission for every line of code. It's about being a co
 
 **Agents (intelligent):**
 - Review code against standards
-- Fix review feedback
+- Count cycles (via `gh pr view --json reviews`) and enforce the cap
+- Detect the staging-vs-main terminal path (via `git ls-remote --heads origin staging`)
+- Run the final-iteration E2E pass and classify findings
+- Fix review feedback and self-smoke-test before pushing
 - Decide what to escalate vs handle autonomously
 - Run `/ultrareview`, `/simplify`
+
+Cycle counting and branch detection are agent-side responsibilities for v1. A future v2 may move cycle counts into the daemon (more reliable than `gh` API at scale), but `gh`-based counting is fine at LobsterFarm volume today.
 
 ## What NOT to Do
 
 - Don't merge without a passing review — even for "trivial" changes
 - Don't skip the re-review after fixes — the reviewer needs to confirm
+- Don't skip the final E2E pass — the deep pass is what catches the bugs unit tests miss
+- Don't run E2E on every iteration — it's the final-step gate, not a per-cycle tax
 - Don't force-merge past conflicts without understanding them
 - Don't auto-resolve merge conflicts that touch the same logic — escalate
 - Don't hold a PR open waiting for a response longer than 24h without re-pinging
+- Don't loop past 3 cycles — escalate to Hunter instead, the loop has exhausted its budget
+- Don't auto-promote staging → main — Hunter's ✅ is the only valid signal, no timeout fallback

--- a/config/claude/skills/pr-review-merge/SKILL.md
+++ b/config/claude/skills/pr-review-merge/SKILL.md
@@ -43,16 +43,35 @@ Spawn a reviewer agent scoped to the PR.
 
 The reviewer:
 - Loads `review-dna` for our review standards (priority order, comment format, frontend criteria, CI awareness, E2E classification, spec-gap heuristic)
-- **Counts prior review cycles** via `gh pr view <n> --json reviews` before starting. Each prior `Reviewer`-authored review (or findings comment with a `Verdict:` line) is a cycle.
+- **Counts prior review cycles** before starting (see the "Cycle cap" block below — multi-dev mode counts formal reviews, single-dev mode counts findings comments). Each prior `Reviewer`-authored review or findings comment with a `**Verdict:` line is a cycle.
 - Runs `/ultrareview` (Claude Code's parallel multi-agent PR review) for comprehensive analysis
 - Posts the review on the PR via `gh`
 - Verdict: **Approved** or **Changes Requested** — never ambiguous
 
 **Cycle cap (hard limit: 3):**
 
+The Reviewer counts prior cycles before starting. The query depends on whether this is a multi-dev or single-dev repo — detect by comparing the Reviewer's GitHub login to the PR author's login:
+
 ```bash
-gh pr view <n> --json reviews --jq '[.reviews[] | select(.author.login == "<reviewer-login>")] | length'
+REVIEWER_LOGIN=$(gh api user --jq '.login')
+PR_AUTHOR=$(gh pr view <n> --json author --jq '.author.login')
 ```
+
+**Mode 1 — Multi-dev repo (`$REVIEWER_LOGIN` ≠ `$PR_AUTHOR`):** count formal `PullRequestReview` entries authored by the Reviewer.
+
+```bash
+gh pr view <n> --json reviews --jq --arg login "$REVIEWER_LOGIN" \
+  '[.reviews[] | select(.author.login == $login)] | length'
+```
+
+**Mode 2 — Single-dev repo (`$REVIEWER_LOGIN` == `$PR_AUTHOR`, currently all of LobsterFarm):** GitHub blocks `gh pr review --approve` on self-authored PRs, so the Reviewer posts findings comments instead of formal reviews (see "Self-approval blocker" below). Count those findings comments instead.
+
+```bash
+gh pr view <n> --json comments --jq \
+  '[.comments[] | select(.body | startswith("**Verdict:"))] | length'
+```
+
+Whichever count applies, interpret it the same way:
 
 - `0` prior cycles → this is cycle 1, proceed normally
 - `1` prior → cycle 2, proceed normally
@@ -80,7 +99,7 @@ Ben:
 
 ### 3. Re-review
 
-After fixes are pushed, loop back to step 1. A fresh reviewer session — no memory of the previous review. Fresh eyes every time. The cycle counter (read from `gh pr view --json reviews`) tells the new Reviewer where it sits in the loop budget.
+After fixes are pushed, loop back to step 1. A fresh reviewer session — no memory of the previous review. Fresh eyes every time. The cycle counter (read per the mode-aware query in step 1) tells the new Reviewer where it sits in the loop budget.
 
 The loop continues until the Reviewer would post Approved — at which point step 3.5 fires before the merge.
 
@@ -118,11 +137,14 @@ Branch existence is the only signal — no per-repo config flag. If the repo gro
 
 1. **Check for conflicts** — `gh pr view {number} --json mergeable`
 2. **Resolve conflicts** if needed (per the rebase rules in 4b below)
-3. **Squash-merge the PR into `staging`:**
+3. **Squash-merge the PR into `staging`** — `gh pr merge` has no `--base` flag, so this is two explicit steps:
    ```bash
-   gh pr merge {number} --squash --delete-branch --base staging
+   # If PR was opened against main, reroute it first:
+   gh pr edit {number} --base staging
+   # Then merge:
+   gh pr merge {number} --squash --delete-branch
    ```
-   (If the PR was opened against `main`, change its base to `staging` first: `gh pr edit {number} --base staging`.)
+   If the PR is already based on `staging`, skip the `gh pr edit` and run the merge directly.
 4. **Post step-by-step test instructions** in two places — same content, two formats:
    - **Discord post in #work-log:**
      ```
@@ -193,14 +215,14 @@ This isn't about asking permission for every line of code. It's about being a co
 
 **Agents (intelligent):**
 - Review code against standards
-- Count cycles (via `gh pr view --json reviews`) and enforce the cap
+- Count cycles (via `gh pr view --json reviews` in multi-dev mode, `--json comments` in single-dev mode) and enforce the cap
 - Detect the staging-vs-main terminal path (via `git ls-remote --heads origin staging`)
 - Run the final-iteration E2E pass and classify findings
 - Fix review feedback and self-smoke-test before pushing
 - Decide what to escalate vs handle autonomously
 - Run `/ultrareview`, `/simplify`
 
-Cycle counting and branch detection are agent-side responsibilities for v1. A future v2 may move cycle counts into the daemon (more reliable than `gh` API at scale), but `gh`-based counting is fine at LobsterFarm volume today.
+Cycle counting and branch detection are agent-side responsibilities for v1. A future v2 may move cycle counts into the daemon (more reliable than `gh` API at scale, and removes the multi-dev/single-dev branching), but `gh`-based counting is fine at LobsterFarm volume today.
 
 ## What NOT to Do
 

--- a/config/claude/skills/review-dna/SKILL.md
+++ b/config/claude/skills/review-dna/SKILL.md
@@ -35,3 +35,62 @@ Every blocking comment must include:
 - Reviewing only the diff without understanding the issue/spec context
 - Blocking on formatting or style (linters handle this)
 - Requesting changes on more than one round — if your feedback is clear, one round is enough
+
+---
+
+## E2E pass — blocking vs. non-blocking
+
+The final review iteration includes an end-to-end pass: playwright tests if the repo has them, plus access-tool exercise of the feature (browser automation, DB queries, API calls — whatever the feature touches). That pass produces findings that need to be classified before you decide the verdict.
+
+**🔴 Blocking — flip verdict to Changes Requested:**
+
+- Acceptance criterion in the spec is not met when exercised end-to-end (the unit tests passed but the user-facing behavior is broken)
+- Crash, 500, unhandled promise rejection, or visible error state on a happy-path flow
+- Data integrity break — wrong values written to the DB, persisted state diverges from what the UI shows, idempotent operation produces duplicates
+- Auth / permission boundary breached (any action a user shouldn't be able to do, that they can)
+- Security regression observable through the UI or API (token leaked into HTML, secret echoed in a response, missing CSRF on a state-changing endpoint)
+- Performance cliff — happy path takes >10× the budget the spec or comparable existing flow sets
+
+**🟡 Non-blocking — note in the E2E comment, do not request changes:**
+
+- Pre-existing issue you stumbled into that's outside the PR's scope (file an issue separately, link from your comment)
+- Minor copy / spacing / styling nit that a linter or designer would catch
+- Edge case the spec didn't ask for and a reasonable user wouldn't hit
+- Flake that doesn't reproduce on a second run (note it, don't block)
+
+**The decision rule:** if a reasonable user following the spec's described path would notice this, it's blocking. If they'd have to be looking for it, it's non-blocking.
+
+Post the E2E result as a single PR comment that lists every finding under the right heading. The verdict (Approved or Changes Requested) is determined by whether the blocking list is empty.
+
+---
+
+## Spec-gap detection — bug vs. ambiguous spec
+
+When something looks wrong, decide whether it's a bug (Ben implemented the wrong thing) or a spec gap (the spec didn't say what the right thing was). The two routes are different and routing it wrong wastes everyone's time.
+
+**It's a bug — request changes from Ben:**
+
+- The spec says X, the code does Y, and X is unambiguous
+- An acceptance criterion is testable and the code fails it
+- Pattern violation against an established DNA rule (security, robustness, naming, error handling)
+- Regression in existing behavior the spec didn't touch
+
+**It's a spec gap — pause and ping Tidus in #alerts:**
+
+- The spec is silent on a decision the implementation had to make, and either choice is defensible
+- Two acceptance criteria are in tension and the spec doesn't say which wins
+- The spec assumes a precondition that isn't true in the code or environment
+- Edge case the spec didn't anticipate, where guessing wrong has user-visible consequences
+- Terminology mismatch — the spec uses one name, the codebase uses another, and you're not sure which is canonical
+
+**Spec-gap escalation format (post in #alerts, ping Tidus):**
+
+```
+PR: <link>
+Ambiguity: <one-sentence description>
+Where Ben landed: <what the code does>
+Other defensible reading: <what the spec might have meant instead>
+Proposed clarification: <what you'd add to the spec to remove the ambiguity>
+```
+
+While the spec gap is being resolved, the cycle counter does **not** advance. Spec gaps aren't Ben's fault and shouldn't burn his budget. When Tidus replies with the clarification (and amends the GitHub issue), Ben implements against the updated spec and the loop continues from where it paused.

--- a/config/claude/skills/review-dna/SKILL.md
+++ b/config/claude/skills/review-dna/SKILL.md
@@ -49,7 +49,7 @@ The final review iteration includes an end-to-end pass: playwright tests if the 
 - Data integrity break — wrong values written to the DB, persisted state diverges from what the UI shows, idempotent operation produces duplicates
 - Auth / permission boundary breached (any action a user shouldn't be able to do, that they can)
 - Security regression observable through the UI or API (token leaked into HTML, secret echoed in a response, missing CSRF on a state-changing endpoint)
-- Performance cliff — happy path takes >10× the budget the spec or comparable existing flow sets
+- Performance cliff — happy path takes >10× the budget the spec or comparable existing flow sets. If neither applies, use absolute thresholds: >3s for a page load, >500ms for an API response under no load. When in doubt, note it as non-blocking and let the team set the budget.
 
 **🟡 Non-blocking — note in the E2E comment, do not request changes:**
 


### PR DESCRIPTION
## Summary

Implements the spec from #38: when Ben is assigned an issue, the team runs the full implement -> review -> fix -> E2E -> merge cycle without requiring Hunter on each step. Hunter is pulled in only at the staging gate (for repos with `origin/staging`) or via the standing escalation rules (production, money, auth, irreversible, security).

## DNA changes

### `coding-dna/SKILL.md`
- New "Self-smoke-test before every push" subsection under Git. Canonical command for this repo is `scripts/run-tests-isolated.sh pnpm -r test`; documents the per-package fallback and the test-infra-failure exception (push with a note rather than silently push past red).

### `pr-review-merge/SKILL.md`
- Step 1: cycle counting via `gh pr view --json reviews`. Hard cap at 3 — a 4th iteration escalates to Hunter in #alerts instead of looping.
- Step 1: documents the self-approval workaround for single-committer repos. `gh pr review --approve` is blocked on self-authored PRs, so the Reviewer posts a findings comment with `**Verdict: Approved**` (or `Changes Requested`) on the first line. The merge step treats that as a valid signal.
- New Step 3.5: E2E pass on the **final iteration only**. Reviewer detects playwright/cypress/e2e suites, exercises the feature with access tools, classifies findings (blocking vs. non-blocking) per the rubric in `review-dna`. Blocker -> flip to Changes Requested + counts as a cycle. Includes a flake policy (re-run once).
- Step 4 split into 4a (origin/staging exists -> staging gate -> Hunter ✅ -> ff to main) and 4b (main only -> straight squash merge). Detection via `git ls-remote --heads origin staging` — no per-repo config flag.
- Step 4a includes the staging test plan format (Discord prose in #work-log + markdown checklist in PR comment, same content) and the no-auto-promotion rule.

### `review-dna/SKILL.md`
- New "E2E pass — blocking vs. non-blocking" section. Crash / 500 / unhandled rejection on the happy path, data-integrity break, auth boundary breach, security regression, perf cliff, unmet acceptance criterion = blocking. Pre-existing issues, copy nits, edge cases the spec didn't ask for, single-run flakes = non-blocking. Decision rule: if a reasonable user following the spec would notice, it's blocking.
- New "Spec-gap detection — bug vs. ambiguous spec" section. Bug -> request changes from Ben (cycle++). Spec gap -> pause the loop, ping Tidus in #alerts with the documented escalation format, **cycle counter does not advance**.

### `feature-lifecycle/SKILL.md` (path migration)
- **Path discrepancy resolved:** this skill previously lived only at `~/.claude/skills/feature-lifecycle/SKILL.md` (user-global), not in the repo. The other three DNA files are managed in-repo. I brought `feature-lifecycle` under repo management at `config/claude/skills/feature-lifecycle/SKILL.md` so this critical SOP is versioned, reviewed, and shipped through the same loop as the rest of the DNA. Flagging explicitly per the work request. The user-global copy is now stale — a follow-up should sync it from the repo (or remove it in favor of the repo-managed copy).
- **Approval gate demoted to legacy.** Autonomous loop is the new default. The legacy gate is reserved for visual work where Hunter wants a preview, or specs that opt in via `verification: user`.
- **New autonomous-loop section** describing: auto-trigger on Ben assignment, 3-cycle cap with escalation, final-iteration E2E, branch-aware terminal step, spec-gap pause-and-ping-Tidus (no cycle increment), unchanged escalation rules, Hunter's ability to intervene mid-loop.
- **Normalized stale agent names** (Gary/Bob/Pearl/Ray -> Tidus/Ben/Helen/Karim) per the opportunistic-cleanup note in the spec.
- Added `feature-lifecycle/` line to `config/claude/skills/README.md`.

## Dogfood note

Hunter wanted this change shipped through the new loop it defines. This PR is the first feature through the system. The terminal step here is 4b (lobster-farm has no `origin/staging` — verified with `git ls-remote --heads origin staging`), so on Reviewer's final approval + clean E2E this squash-merges straight to main.

## Acceptance criteria (from #38)

- [x] Hunter can assign Ben to a GitHub issue and walk away (codified in `feature-lifecycle`)
- [x] Default behavior produces a merged PR (or staging-gate ping) without Hunter touching anything (`pr-review-merge` step 4a/4b)
- [x] Loop cap correctly escalates after 3 review cycles (`pr-review-merge` step 1)
- [x] E2E runs on the final iteration only, not every iteration (`pr-review-merge` step 3.5)
- [x] Repos with `origin/staging` route through the staging gate, both #work-log and PR-comment artifacts (`pr-review-merge` step 4a)
- [x] Repos with only `origin/main` autonomously merge to main (`pr-review-merge` step 4b)
- [x] Existing escalation rules (production, money, etc.) still trigger Hunter pings (`feature-lifecycle` "Escalation rules unchanged")
- [x] Spec-gap escalations route to Tidus in #alerts, not Hunter, and don't advance the cycle counter (`review-dna` + `pr-review-merge` step 1)
- [x] Smoke-test failures block pushes from Ben (`coding-dna` self-smoke section)

## Test plan

- [ ] Reviewer agent loads `review-dna` and applies the E2E rubric / spec-gap heuristic on a real PR
- [ ] Cycle counter via `gh pr view --json reviews` correctly identifies cycle 1/2/3 on a multi-round PR
- [ ] Branch detection (`git ls-remote --heads origin staging`) routes lobster-farm to 4b and a staging-having repo to 4a
- [ ] Self-smoke gate prevents Ben from pushing on a red suite (or pushes with a note when test infra fails)

Closes #38

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>