### PR TITLE
refactor(daemon): post-merge cleanup for reply-enforcement (follow-up to #41)

### DIFF
--- a/packages/daemon/src/__tests__/reply-enforcement.test.ts
+++ b/packages/daemon/src/__tests__/reply-enforcement.test.ts
@@ -229,6 +229,25 @@ describe("read_last_assistant_turn", () => {
     expect(turn.produced_text).toBe(true);
   });
 
+  it("returns found=false on a zero-byte JSONL (empty-file edge case)", async () => {
+    // Edge case: file exists but has zero bytes (a flush race window where
+    // open() has created the file but no events have landed). The retry loop
+    // settles when size stops growing, then the empty-content guard returns
+    // found=false so the caller treats this as pass-through.
+    const path = join(
+      temp_home,
+      ".claude",
+      "projects",
+      encode_project_slug(working_dir),
+      `${session_id}.jsonl`,
+    );
+    await writeFile(path, "", "utf-8");
+    const turn = await read_last_assistant_turn(working_dir, session_id);
+    expect(turn.found).toBe(false);
+    expect(turn.produced_text).toBe(false);
+    expect(turn.called_reply).toBe(false);
+  });
+
   it("tolerates a brief flush delay (race mitigation)", async () => {
     const path = join(
       temp_home,
@@ -290,6 +309,28 @@ describe("resolve_bound_channel / is_discord_bound", () => {
   it("returns null when pool is null", () => {
     expect(resolve_bound_channel("S1", null)).toBeNull();
     expect(is_discord_bound("S1", null)).toBe(false);
+  });
+
+  it("returns null for subagent session_ids (subagent sessions are never in the pool assignment map)", () => {
+    // Subagents inherit the parent's working dir but get their own session_id
+    // from Claude Code. They are never assigned a pool bot, so they never
+    // appear in the assignment map — pool binding is the primary defense
+    // against subagent Stop events triggering enforcement.
+    const parent_session_id = "parent-S";
+    const subagent_session_id = "subagent-S";
+    const pool = make_pool([
+      make_bot({
+        id: 1,
+        state: "assigned",
+        channel_id: "C123",
+        entity_id: "lobster-farm",
+        session_id: parent_session_id,
+      }),
+    ]);
+    expect(resolve_bound_channel(subagent_session_id, pool)).toBeNull();
+    expect(is_discord_bound(subagent_session_id, pool)).toBe(false);
+    // Sanity: the parent still resolves.
+    expect(is_discord_bound(parent_session_id, pool)).toBe(true);
   });
 });
 
@@ -543,6 +584,27 @@ describe("evaluate_stop — acceptance criteria", () => {
     );
     expect(result).toEqual({ ok: true });
     expect(sends.length).toBe(0);
+  });
+
+  it("silent turn with bound channel but null discord → pass-through, no Haiku call", async () => {
+    // Defends the null-discord short-circuit: if a channel is bound but the
+    // discord client somehow isn't wired (partial-startup edge case), we must
+    // not burn a Haiku round-trip just to discard it.
+    let heartbeat_called = false;
+    const result = await evaluate_stop(
+      { session_id, working_dir },
+      {
+        pool: bound_pool(),
+        discord: null,
+        read_turn: make_turn_reader({ produced_text: false, called_reply: false }),
+        make_heartbeat: async () => {
+          heartbeat_called = true;
+          return "should not run";
+        },
+      },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(heartbeat_called).toBe(false);
   });
 
   it("null pool (daemon without Discord) → pass-through", async () => {

--- a/packages/daemon/src/reply-enforcement.ts
+++ b/packages/daemon/src/reply-enforcement.ts
@@ -65,9 +65,7 @@ export interface TurnSummary {
   found: boolean;
 }
 
-export type StopHookResponse =
-  | { ok: true; block?: false }
-  | { ok: true; block: true; reminder: string };
+export type StopHookResponse = { ok: true } | { ok: true; block: true; reminder: string };
 
 export interface EvaluateStopDeps {
   pool: BotPool | null;
@@ -143,7 +141,7 @@ export async function read_last_assistant_turn(
     try {
       next = await readFile(path, "utf-8");
     } catch {
-      // File not yet written.
+      // File not yet on disk; retry within budget.
       continue;
     }
     if (next.length === last_size) {
@@ -374,10 +372,17 @@ export async function evaluate_stop(
       return { ok: true };
     }
 
+    // Null-discord guard sits BEFORE the Haiku call so we don't burn an API
+    // round-trip in the (theoretical) case where a channel is bound but the
+    // discord client isn't wired (e.g., daemon during a partial-startup window).
+    if (!deps.discord) {
+      return { ok: true };
+    }
+
     try {
       const summary = await make_heartbeat(turn);
       const trimmed = summary.trim();
-      if (trimmed && deps.discord) {
+      if (trimmed) {
         await deps.discord.send(channel_id, `${HEARTBEAT_PREFIX}${trimmed}`);
         mark_cooldown(channel_id, now);
       }


### PR DESCRIPTION
## Summary

Five minor cleanup items surfaced in the post-merge review of PR #41. All hardening + clarity, no behavior change in the happy paths. The one behavioral edge: a null-`discord` guard moves above the Haiku call in `evaluate_stop`'s heartbeat branch, avoiding a wasted API round-trip in a (theoretical) partial-startup window where a channel is bound but the discord client isn't wired.

This is a **follow-up to PR #41** — does NOT close any issue. The original spec issue (#39) auto-closed on #41's merge.

## Changes

| # | File | Change |
|---|------|--------|
| 1 | `packages/daemon/src/reply-enforcement.ts` | Move `deps.discord` null check above the `make_heartbeat` call in `evaluate_stop`'s failure-mode-(b) branch |
| 2 | `packages/daemon/src/reply-enforcement.ts` | Simplify `StopHookResponse` union — drop the dead `{ ok: true; block?: false }` arm |
| 3 | `packages/daemon/src/reply-enforcement.ts` | Rephrase the misleading `// File not yet written.` comment in the JSONL retry-loop catch to `// File not yet on disk; retry within budget.` (the catch arm continues the loop, doesn't return) |
| 4 | `packages/daemon/src/__tests__/reply-enforcement.test.ts` | Add explicit subagent-named test for `resolve_bound_channel` / `is_discord_bound` so future readers can grep "subagent" and find the guard |
| 5 | `packages/daemon/src/__tests__/reply-enforcement.test.ts` | Add empty-file edge-case test for `read_last_assistant_turn` — zero-byte JSONL settles cleanly to `found: false` |
| + | `packages/daemon/src/__tests__/reply-enforcement.test.ts` | Add null-discord-with-bound-channel test in `evaluate_stop` to lock the new short-circuit: Haiku must NOT be invoked when discord is null |

## Test plan

- [x] `scripts/run-tests-isolated.sh pnpm --filter @lobster-farm/daemon test` — all 1195 tests pass (was 1192 pre-change after main caught up with #44 etc.; +3 new tests)
- [x] `pnpm exec tsc --noEmit -p packages/daemon` — clean
- [x] Pre-commit hooks ran clean (formatter collapsed the `StopHookResponse` union to a single line; cosmetic)

## References

- Follow-up to PR #41
- Reviewer comment that surfaced these: https://github.com/hkelley44/lobster-farm/pull/41#issuecomment-4413703168
- Original spec issue: #39 (closed on #41 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)