### PR TITLE
fix(agents): normalize archetype frontmatter (closes #49)

### DIFF
--- a/config/claude/agents/builder.md
+++ b/config/claude/agents/builder.md
@@ -6,7 +6,8 @@ description: >
   writing production code. Loads additional DNA (design-dna, database-dna) based
   on what the task involves.
 model: opus
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+permissionMode: bypassPermissions
 ---
 
 # {{BUILDER_NAME}} — Soul

--- a/config/claude/agents/commander.md
+++ b/config/claude/agents/commander.md
@@ -6,7 +6,8 @@ description: >
   on the LobsterFarm platform itself.
   The only agent that operates at the platform level, not the entity level.
 model: opus
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+permissionMode: bypassPermissions
 ---
 
 # {{COMMANDER_NAME}} — Soul

--- a/config/claude/agents/designer.md
+++ b/config/claude/agents/designer.md
@@ -6,7 +6,8 @@ description: >
   task where visual quality and user experience are primary concerns. Designs
   in code, not mockups.
 model: opus
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+permissionMode: bypassPermissions
 ---
 
 # {{DESIGNER_NAME}} — Soul

--- a/config/claude/agents/operator.md
+++ b/config/claude/agents/operator.md
@@ -5,7 +5,8 @@ description: >
   setup, infrastructure management, monitoring, Sentry triage, server
   maintenance, and incident response.
 model: sonnet
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+permissionMode: bypassPermissions
 ---
 
 # {{OPERATOR_NAME}} — Soul

--- a/config/claude/agents/planner.md
+++ b/config/claude/agents/planner.md
@@ -5,7 +5,8 @@ description: >
   project scoping, architecture decisions, spec writing, socratic discovery
   sessions, and project management. Use when defining WHAT to build and WHY.
 model: opus
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+permissionMode: bypassPermissions
 ---
 
 # {{PLANNER_NAME}} — Soul

--- a/config/claude/agents/reviewer.md
+++ b/config/claude/agents/reviewer.md
@@ -5,7 +5,8 @@ description: >
   quality checks, and security audits. Always ephemeral — no memory of
   building the feature. Fresh eyes every time.
 model: sonnet
-allowed-tools: Read, Glob, Grep, Bash
+tools: Read, Glob, Grep, Bash
+permissionMode: bypassPermissions
 initialPrompt: |
   You are performing a pull-request review as the LobsterFarm Reviewer GitHub
   App. The PR-specific context follows this message — read it carefully


### PR DESCRIPTION
## Summary

Fixes #49 — spawned subagents getting `"Permission to use Bash has been denied"` rejections on Bash/Read against worktree paths, while parent Tidus sessions worked fine in the same tree. Was blocking all Ben work.

**Root cause: frontmatter drift in `config/claude/agents/*.md`** (and the corresponding live files in `~/.claude/agents/`):

1. **`allowed-tools:` is not a valid frontmatter field.** Canonical name per the Claude Code subagent spec is `tools:`. The wrong name was a silent no-op (agents defaulted to inheriting parent tools), so the typo was invisible until a separate behavior surfaced it.
2. **`permissionMode: bypassPermissions` was missing** on `planner.md`, `commander.md`, and `reviewer.md`. Already present on `builder.md`, `designer.md`, `operator.md`. Docs say parent `defaultMode: "bypassPermissions"` should cascade and take precedence over the child — empirically on harness v2.1.87 the cascade fails for custom-defined agents (built-in subagent types like `general-purpose` and `claude-code-guide` are unaffected; verified by control case in the diagnosing session). Explicit `permissionMode: bypassPermissions` on each archetype is defense-in-depth against this cascade gap.

## Changes

All six archetypes now use the canonical shape:

```yaml
tools: <comma-separated tool list>
permissionMode: bypassPermissions
```

| File | Before | After |
|---|---|---|
| `builder.md` | `allowed-tools: ...` + had `permissionMode` | `tools: ...` + `permissionMode` |
| `commander.md` | `allowed-tools: ...` (no permissionMode) | `tools: ...` + `permissionMode` |
| `designer.md` | `allowed-tools: ...` + had `permissionMode` | `tools: ...` + `permissionMode` |
| `operator.md` | `allowed-tools: ...` + had `permissionMode` | `tools: ...` + `permissionMode` |
| `planner.md` | `allowed-tools: ...` (no permissionMode) | `tools: ...` + `permissionMode` |
| `reviewer.md` | `allowed-tools: ...` (no permissionMode) | `tools: ...` + `permissionMode` |

The Reviewer's narrower toolset (`Read, Glob, Grep, Bash`) is preserved.

## Out of band — also fixed on disk

This PR only updates the in-repo `config/claude/agents/*.md` templates (what new `lf init` runs produce). The live `~/.claude/agents/*.md` files on Hunter's machine have already been hand-patched in parallel so the bug is unblocked **after the next session restart** — the PR brings the source-of-truth template in line so future fresh installs get the right defaults.

## Spec reference

https://code.claude.com/docs/en/sub-agents.md#supported-frontmatter-fields

## Acceptance criteria (from #49)

- [ ] Spawn each archetype as a subagent; Bash / Read / Edit on a worktree path succeeds without prompts. **(requires daemon restart to verify)**
- [ ] Parent Tidus session continues to work unchanged.
- [x] Documented in MEMORY.md (separate update — entity state, not in this PR).

## Test plan

- [ ] Hunter (or daemon) restarts the active session(s) to reload agent .md files.
- [ ] Spawn Ben on a trivial task: `ls ~/.lobsterfarm/src && git status`. Should complete without `"Permission to use Bash has been denied"`.
- [ ] Spawn Reviewer on a closed PR. Should complete its read-only review without permission rejections.
- [ ] Sanity: parent Tidus continues to work as today.

## Known follow-up

If the cascade gap reproduces after this fix, that's an upstream harness regression for `/feedback` — but the explicit `permissionMode` field is a robust workaround either way.

Closes #49

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>