### PR TITLE
refactor(agents): drop tools allowlist from archetype frontmatter

### DIFF
--- a/config/claude/agents/README.md
+++ b/config/claude/agents/README.md
@@ -9,6 +9,6 @@ Agent names use `{{PLACEHOLDER}}` variables so each installation can customize t
 - `planner.md` -- Gary. Strategic planner and project coordinator. Socratic discovery, spec writing, scope management. Uses Opus.
 - `designer.md` -- Pearl. Design engineer. Brand kits, design systems, component libraries. Designs in code, not mockups. Uses Opus.
 - `builder.md` -- Bob. Full-stack engineer. Feature implementation, testing, documentation. Clarity over cleverness. Uses Opus.
-- `reviewer.md` -- Reviewer. Code review and QA gate. Always ephemeral -- no memory of building the feature. Uses Sonnet. Has reduced tool access (Read, Glob, Grep, Bash only).
+- `reviewer.md` -- Reviewer. Code review and QA gate. Always ephemeral -- no memory of building the feature. Uses Sonnet. Inherits full parent toolset; if write-blind guardrail is desired, add `disallowedTools: Edit, Write, NotebookEdit`.
 - `operator.md` -- Ray. DevOps and operations. Deployment, CI/CD, monitoring, incident response. Uses Sonnet.
 - `commander.md` -- Pat. System administrator and orchestrator. The only agent that operates at the platform level. Connected to Discord via the channel plugin. Uses Opus.

--- a/config/claude/agents/README.md
+++ b/config/claude/agents/README.md
@@ -1,6 +1,6 @@
 # Agent Archetypes
 
-Soul files for each agent role. These are Claude Code agent definitions (markdown with YAML frontmatter) that get copied to `~/.claude/agents/` during `lf init`. The frontmatter specifies the agent name, description, model, and allowed tools. The body defines the agent's personality, working style, and domain expertise.
+Soul files for each agent role. These are Claude Code agent definitions (markdown with YAML frontmatter) that get copied to `~/.claude/agents/` during `lf init`. The frontmatter specifies the agent name, description, model, and permission mode. Tools are not allowlisted — every agent inherits the parent session's full tool palette (including MCP plugin tools, `Task` for orchestration, web tools, etc.). If selective restriction is ever needed, use `disallowedTools:` as a per-agent denylist rather than an explicit `tools:` allowlist. The body defines the agent's personality, working style, and domain expertise.
 
 Agent names use `{{PLACEHOLDER}}` variables so each installation can customize them (defaults: Gary, Pearl, Bob, Ray, Pat).
 

--- a/config/claude/agents/builder.md
+++ b/config/claude/agents/builder.md
@@ -6,7 +6,6 @@ description: >
   writing production code. Loads additional DNA (design-dna, database-dna) based
   on what the task involves.
 model: opus
-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 permissionMode: bypassPermissions
 ---
 

--- a/config/claude/agents/commander.md
+++ b/config/claude/agents/commander.md
@@ -6,7 +6,6 @@ description: >
   on the LobsterFarm platform itself.
   The only agent that operates at the platform level, not the entity level.
 model: opus
-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 permissionMode: bypassPermissions
 ---
 

--- a/config/claude/agents/designer.md
+++ b/config/claude/agents/designer.md
@@ -6,7 +6,6 @@ description: >
   task where visual quality and user experience are primary concerns. Designs
   in code, not mockups.
 model: opus
-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 permissionMode: bypassPermissions
 ---
 

--- a/config/claude/agents/operator.md
+++ b/config/claude/agents/operator.md
@@ -5,7 +5,6 @@ description: >
   setup, infrastructure management, monitoring, Sentry triage, server
   maintenance, and incident response.
 model: sonnet
-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 permissionMode: bypassPermissions
 ---
 

--- a/config/claude/agents/planner.md
+++ b/config/claude/agents/planner.md
@@ -5,7 +5,6 @@ description: >
   project scoping, architecture decisions, spec writing, socratic discovery
   sessions, and project management. Use when defining WHAT to build and WHY.
 model: opus
-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 permissionMode: bypassPermissions
 ---
 

--- a/config/claude/agents/reviewer.md
+++ b/config/claude/agents/reviewer.md
@@ -5,7 +5,6 @@ description: >
   quality checks, and security audits. Always ephemeral — no memory of
   building the feature. Fresh eyes every time.
 model: sonnet
-tools: Read, Glob, Grep, Bash
 permissionMode: bypassPermissions
 initialPrompt: |
   You are performing a pull-request review as the LobsterFarm Reviewer GitHub


### PR DESCRIPTION
## Summary

Follow-up to #50. Removes `tools:` from each archetype's frontmatter so agents inherit the parent session's full tool palette instead of being constrained by an explicit allowlist.

## Why

With `tools:` declared, the harness strictly enforces the allowlist after a session restart. That broke two capabilities the platform depended on:

1. **Orchestration** — Tidus's tools list didn't include `Task`, so Tidus could no longer spawn subagents (Ben/Helen/Karim/Edgard/Reviewer). Directly breaks the orchestrator pattern documented in CLAUDE.md ("Tidus is the orchestrator… spawns other agents as subagents").
2. **Discord** — no agent listed `mcp__plugin_discord_discord__reply`, so once the allowlist was honored, no agent could reply to Hunter on Discord. Effectively cuts off the human-in-the-loop channel.

Both were latent capabilities. The original `allowed-tools:` field (the typo that #50 fixed) was a silent no-op, so the harness defaulted parents and subagents to "all tools available" — Tidus had `Task` and `mcp__plugin_discord_discord__reply` by accident. Once #50 corrected the field name to spec'd `tools:`, the allowlist became enforceable and the latent capabilities disappeared on the next restart.

Hunter confirmed the original intent was declaration, not enforcement. Dropping the field restores the pre-#49 capability surface while keeping the actual #49 fix (`permissionMode: bypassPermissions` on every archetype) intact.

## What this PR does NOT change

- `permissionMode: bypassPermissions` remains on all six archetypes. That's the load-bearing field for #49's actual fix (subagent permission cascade).
- Model, description, name, initialPrompt — unchanged.
- The behavior for new entities scaffolded via `lf init` will inherit the fixed templates.

## Reviewer note — narrow-toolset loss for `reviewer.md`

Pre-PR: `reviewer.md` declared `tools: Read, Glob, Grep, Bash` (no Write/Edit/Skill) — an intentional guardrail to keep the QA gate read-only and prevent it from accidentally mutating PR branches mid-review.

Post-PR: Reviewer inherits the parent's full toolset, including Write/Edit. The guardrail is gone.

This was a conscious tradeoff in choosing this approach. If we want Reviewer to remain write-blind, the right follow-up is:

```yaml
# reviewer.md
disallowedTools: Edit, Write, NotebookEdit
```

That's a denylist applied on top of inherited tools — Reviewer keeps Task, Skill, plugin tools, web tools, but cannot Write/Edit. Not included in this PR; flagged for separate consideration.

## Future tool restriction guidance

If selective restriction is ever needed, use `disallowedTools:` (denylist) rather than `tools:` (allowlist). A denylist on top of inheritance preserves orchestration and plugin tools by default, only loses the specific tools listed. An allowlist requires every desired tool to be explicitly enumerated and updated whenever a new MCP tool or harness capability is added.

README in `config/claude/agents/` updated to document this convention.

## Test plan

- [ ] Hunter restarts the daemon (or this session) to pick up the new agent definitions.
- [ ] Spawn Ben on a trivial task — `ls && git status && Read a file && Edit a /tmp file`. Should complete cleanly.
- [ ] Tidus can spawn Ben/Helen/Karim subagents via `Task`.
- [ ] Any agent can reply to Hunter on Discord via `mcp__plugin_discord_discord__reply`.
- [ ] Reviewer remains usable (toolset wider than before, but still works).

## Spec reference

- Subagent frontmatter: https://code.claude.com/docs/en/sub-agents.md#supported-frontmatter-fields
- `disallowedTools` field documented alongside `tools` in the same spec.

Refs #49 (the original bug — fully addressed by #50 + this PR together).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>