### PR TITLE
chore(dna): symlink user-global skills to repo as canonical source (closes #45)

### DIFF
--- a/config/claude/skills/README.md
+++ b/config/claude/skills/README.md
@@ -8,6 +8,25 @@ Skills fall into three categories:
 - **Guidelines** -- Operational requirements. Secret handling, code review standards, README maintenance, Discord management. Loaded across archetypes as needed.
 - **SOPs** -- Step-by-step procedures. PR review-merge workflow, entity scaffolding process. Loaded when executing a specific process.
 
+## Canonical source rule
+
+**This directory (`config/claude/skills/`) is the single source of truth for every skill.** The Claude Code harness only auto-discovers skills under `~/.claude/skills/`, so each shared skill is published to that load path as a **symlink** pointing at the repo file here. Never edit a user-global `~/.claude/skills/<name>/SKILL.md` directly — edit the repo file in this directory, commit it through a PR, and the symlinked user-global copy reflects the change immediately (the harness picks it up on the next session start).
+
+When adding a new shared skill:
+
+1. Create `config/claude/skills/<name>/SKILL.md` here and commit it through a PR.
+2. After merge, publish to the user-global load path on each machine:
+   ```bash
+   mkdir -p ~/.claude/skills/<name>
+   ln -s ~/.lobsterfarm/src/config/claude/skills/<name>/SKILL.md \
+         ~/.claude/skills/<name>/SKILL.md
+   ```
+3. Verify with `realpath ~/.claude/skills/<name>/SKILL.md` — it must resolve back into `~/.lobsterfarm/src/config/claude/skills/...`.
+
+Repo-only skills (no user-global presence needed) are loaded by agents that explicitly `Skill`-invoke them — they don't need to be published to `~/.claude/skills/`.
+
+If a SKILL.md is ever found as a regular file (not a symlink) under `~/.claude/skills/`, it is drift — replace it with a symlink to the repo file rather than editing in place.
+
 ## Directories
 
 - `coding-dna/` -- Engineering standards and architectural preferences. The foundational DNA for all code work.


### PR DESCRIPTION
Closes #45

## Summary

- Documents the canonical-source rule for shared skills in `config/claude/skills/README.md`: the repo file is the single source of truth and `~/.claude/skills/<name>/SKILL.md` is a symlink that points at it.
- On-machine, applied the symlink dance for all 9 shared skills (`feature-lifecycle`, `database-dna`, `design-dna`, `discord-guideline`, `entity-scaffold`, `planning-dna`, `readme-guideline`, `secrets-guideline`, `sentry-guideline`).
- Removed the orphaned `~/.claude/skills/review-guideline/` (legacy rename of repo's `review-dna`).
- Added a "DNA management" section to the `lobster-farm` entity MEMORY.md capturing the strategy so future sessions don't reintroduce drift.

## Smoke test

Before symlinking: `~/.claude/skills/feature-lifecycle/SKILL.md` was 91 lines, dated Mar 28, mentioned Gary/Bob.
After symlinking: `realpath` resolves into `~/.lobsterfarm/src/config/claude/skills/feature-lifecycle/SKILL.md`; reads via the symlinked path return the May 10 / 154-line / Tidus-Ben rewrite from PR #44. macOS file I/O traverses symlinks transparently, so the harness sees the new content on the next session start (description discovery is snapshotted at boot — the running session keeps its old summary until it cycles).

## Scope note

The repo deliverable in this PR is the README rule (one file, +19 lines). The actual symlink + cleanup steps happen under `~/.claude/skills/` and `~/.lobsterfarm/entities/lobster-farm/MEMORY.md` — both outside the repo. They were performed on this host as part of #45 and are documented in the entity MEMORY.

## Follow-up (not in scope)

- `lf start --upgrade` (or an install-time step) should idempotently publish the user-global symlinks for any new machine — flagged in MEMORY.md and the issue's risk section.

## Test plan

- [x] `realpath ~/.claude/skills/feature-lifecycle/SKILL.md` resolves into `~/.lobsterfarm/src/config/claude/skills/...`
- [x] All 9 shared user-global SKILL.md files are symlinks (verified via `readlink`)
- [x] `~/.claude/skills/review-guideline/` removed
- [x] `wc -l` through the symlink returns the repo's May 10 content (154 lines), not the stale Mar 28 content (91 lines)
- [x] `config/claude/skills/README.md` documents the canonical-source rule
- [x] MEMORY.md note added under a new "DNA management" section
- [ ] Reviewer to confirm the README rule reads clearly and the canonical-source pattern lands