### PR TITLE
fix(daemon): detect findings-comment verdicts + enforce cycle cap in single-dev repos

### DIFF
--- a/packages/daemon/src/__tests__/actions.test.ts
+++ b/packages/daemon/src/__tests__/actions.test.ts
@@ -667,6 +667,200 @@ describe("detect_review_outcome", () => {
   });
 });
 
+// ── Findings-comment verdict fallback (#46) ──
+
+/**
+ * Build an exec mock that mimics the responses `detect_review_outcome` and
+ * `detect_verdict_from_comments` make through the gh CLI:
+ *   - `gh pr view <n> --json state`           → `state`
+ *   - `gh pr view <n> --json reviewDecision`  → `review_decision`
+ *   - `gh api user`                           → `login`
+ *   - `gh pr view <n> --json comments`        → `comments` (JSON-encoded)
+ */
+function set_review_outcome_responses(opts: {
+  state?: string;
+  review_decision?: string;
+  login?: string;
+  comments?: Array<{
+    body: string;
+    createdAt: string;
+    author: { login: string } | null;
+  }>;
+}) {
+  exec_mock_impl = async (_cmd, args) => {
+    if (args[0] === "api" && args[1] === "user") {
+      return { stdout: opts.login ?? "", stderr: "" };
+    }
+    if (args.includes("state")) {
+      return { stdout: opts.state ?? "OPEN", stderr: "" };
+    }
+    if (args.includes("reviewDecision")) {
+      return { stdout: opts.review_decision ?? "", stderr: "" };
+    }
+    if (args.includes("--json") && args.includes("comments")) {
+      return { stdout: JSON.stringify(opts.comments ?? []), stderr: "" };
+    }
+    return { stdout: "", stderr: "" };
+  };
+}
+
+describe("detect_review_outcome — findings-comment fallback (#46)", () => {
+  const REVIEWER = "reviewer-bot";
+
+  it("prefers reviewDecision when present, even if is_self_authored=true", async () => {
+    // Regression guard: if reviewDecision is APPROVED, we must NOT consult
+    // comments — formal reviews always win.
+    set_review_outcome_responses({
+      review_decision: "APPROVED",
+      login: REVIEWER,
+      comments: [
+        // A stale "Changes Requested" comment that would flip the verdict if read.
+        {
+          body: "**Verdict: Changes Requested**\n\nstale",
+          createdAt: "2026-05-09T10:00:00Z",
+          author: { login: REVIEWER },
+        },
+      ],
+    });
+
+    const result = await detect_review_outcome(42, "/repos/test-repo", {
+      is_self_authored: true,
+    });
+
+    expect(result).toBe("approved");
+
+    // And we should never have asked for comments.
+    const comments_call = exec_calls.find(
+      (c) => c.command === "gh" && c.args.includes("--json") && c.args.includes("comments"),
+    );
+    expect(comments_call).toBeUndefined();
+  });
+
+  it("falls back to the comment verdict when reviewDecision is empty and PR is self-authored", async () => {
+    set_review_outcome_responses({
+      review_decision: "",
+      login: REVIEWER,
+      comments: [
+        {
+          body: "**Verdict: Changes Requested**\n\nFix the foo.",
+          createdAt: "2026-05-09T10:00:00Z",
+          author: { login: REVIEWER },
+        },
+      ],
+    });
+
+    const result = await detect_review_outcome(42, "/repos/test-repo", {
+      is_self_authored: true,
+    });
+
+    expect(result).toBe("changes_requested");
+  });
+
+  it("uses the most recent matching comment when multiple exist", async () => {
+    set_review_outcome_responses({
+      review_decision: "",
+      login: REVIEWER,
+      comments: [
+        {
+          body: "**Verdict: Changes Requested**\n\nfirst pass",
+          createdAt: "2026-05-09T10:00:00Z",
+          author: { login: REVIEWER },
+        },
+        {
+          body: "**Verdict: Approved**\n\nafter the fix",
+          createdAt: "2026-05-09T12:00:00Z",
+          author: { login: REVIEWER },
+        },
+      ],
+    });
+
+    const result = await detect_review_outcome(42, "/repos/test-repo", {
+      is_self_authored: true,
+    });
+
+    expect(result).toBe("approved");
+  });
+
+  it("does NOT fall back when is_self_authored is false (multi-dev path)", async () => {
+    set_review_outcome_responses({
+      review_decision: "",
+      login: REVIEWER,
+      comments: [
+        {
+          body: "**Verdict: Approved**\n\nshould be ignored",
+          createdAt: "2026-05-09T10:00:00Z",
+          author: { login: REVIEWER },
+        },
+      ],
+    });
+
+    const result = await detect_review_outcome(42, "/repos/test-repo", {
+      is_self_authored: false,
+    });
+
+    expect(result).toBe("pending");
+
+    // Make sure we never even asked for comments — the multi-dev path must
+    // stay on formal reviews only.
+    const comments_call = exec_calls.find(
+      (c) => c.command === "gh" && c.args.includes("--json") && c.args.includes("comments"),
+    );
+    expect(comments_call).toBeUndefined();
+  });
+
+  it("stays pending when reviewDecision is empty, self-authored, but `gh api user` fails", async () => {
+    // Without an authenticated login we cannot safely filter comments, so the
+    // helper must refuse to guess and leave the outcome pending.
+    exec_mock_impl = async (_cmd, args) => {
+      if (args[0] === "api" && args[1] === "user") {
+        throw new Error("gh: not authenticated");
+      }
+      if (args.includes("state")) return { stdout: "OPEN", stderr: "" };
+      if (args.includes("reviewDecision")) return { stdout: "", stderr: "" };
+      // If we somehow asked for comments anyway, return a verdict to make the
+      // failure mode obvious.
+      if (args.includes("--json") && args.includes("comments")) {
+        return {
+          stdout: JSON.stringify([
+            {
+              body: "**Verdict: Approved**",
+              createdAt: "2026-05-09T10:00:00Z",
+              author: { login: "reviewer-bot" },
+            },
+          ]),
+          stderr: "",
+        };
+      }
+      return { stdout: "", stderr: "" };
+    };
+
+    const result = await detect_review_outcome(42, "/repos/test-repo", {
+      is_self_authored: true,
+    });
+
+    expect(result).toBe("pending");
+  });
+
+  it("accepts the legacy positional gh_token signature (backwards-compat)", async () => {
+    // The old call signature was `detect_review_outcome(pr, repo, gh_token?)`.
+    // We keep that working so existing call sites that haven't migrated still
+    // compile and run correctly.
+    set_review_outcome_responses({ review_decision: "APPROVED" });
+    const result = await detect_review_outcome(42, "/repos/test-repo", "ghs_legacy_token");
+    expect(result).toBe("approved");
+
+    // And the token still gets injected into the gh env.
+    const gh_calls = exec_calls.filter((c) => c.command === "gh");
+    expect(gh_calls.length).toBeGreaterThan(0);
+    for (const call of gh_calls) {
+      const env = (call.options as Record<string, unknown>)?.env as
+        | Record<string, string>
+        | undefined;
+      expect(env?.GH_TOKEN).toBe("ghs_legacy_token");
+    }
+  });
+});
+
 describe("classify_merge_error", () => {
   it("returns 'conflict' for merge conflict errors", () => {
     expect(classify_merge_error("MERGE CONFLICT in file.ts")).toBe("conflict");

--- a/packages/daemon/src/__tests__/actions.test.ts
+++ b/packages/daemon/src/__tests__/actions.test.ts
@@ -859,6 +859,65 @@ describe("detect_review_outcome — findings-comment fallback (#46)", () => {
       expect(env?.GH_TOKEN).toBe("ghs_legacy_token");
     }
   });
+
+  it("merges process.env into the env passed to `gh api user` and `gh pr view --json comments` when gh_token is set", async () => {
+    // Regression guard for cycle-2 review finding: `get_authenticated_login`
+    // and `detect_verdict_from_comments` are called via `exec_async` directly
+    // (not via the local `run()` helper), so they do NOT merge process.env on
+    // their own. If we forward a partial `{ GH_TOKEN }` env, PATH is dropped
+    // and the gh binary can't be located → login resolves to null → comment
+    // fallback silently stays pending. Pin both call sites here so the bug
+    // can't regress unnoticed.
+    const SENTINEL_KEY = "REVIEW_OUTCOME_ENV_SENTINEL";
+    const SENTINEL_VALUE = "preserved-from-process-env";
+    process.env[SENTINEL_KEY] = SENTINEL_VALUE;
+
+    try {
+      set_review_outcome_responses({
+        review_decision: "",
+        login: "reviewer-bot",
+        comments: [
+          {
+            body: "**Verdict: Approved**\n\nlgtm",
+            createdAt: "2026-05-09T10:00:00Z",
+            author: { login: "reviewer-bot" },
+          },
+        ],
+      });
+
+      await detect_review_outcome(42, "/repos/test-repo", {
+        gh_token: "ghs_cross_account_token",
+        is_self_authored: true,
+      });
+
+      // The `gh api user` call (used by get_authenticated_login) must see both
+      // GH_TOKEN AND the sentinel that lives in process.env.
+      const api_user_call = exec_calls.find(
+        (c) => c.command === "gh" && c.args[0] === "api" && c.args[1] === "user",
+      );
+      expect(api_user_call, "expected a `gh api user` call").toBeDefined();
+      const api_user_env = (api_user_call?.options as Record<string, unknown> | undefined)?.env as
+        | Record<string, string>
+        | undefined;
+      expect(api_user_env?.GH_TOKEN).toBe("ghs_cross_account_token");
+      expect(api_user_env?.[SENTINEL_KEY]).toBe(SENTINEL_VALUE);
+
+      // Same for the `gh pr view --json comments` call (used by
+      // detect_verdict_from_comments) — already correct before the fix but
+      // pinned here so the two paths stay consistent.
+      const comments_call = exec_calls.find(
+        (c) => c.command === "gh" && c.args.includes("--json") && c.args.includes("comments"),
+      );
+      expect(comments_call, "expected a `gh pr view --json comments` call").toBeDefined();
+      const comments_env = (comments_call?.options as Record<string, unknown> | undefined)?.env as
+        | Record<string, string>
+        | undefined;
+      expect(comments_env?.GH_TOKEN).toBe("ghs_cross_account_token");
+      expect(comments_env?.[SENTINEL_KEY]).toBe(SENTINEL_VALUE);
+    } finally {
+      delete process.env[SENTINEL_KEY];
+    }
+  });
 });
 
 describe("classify_merge_error", () => {

--- a/packages/daemon/src/__tests__/pr-cron.test.ts
+++ b/packages/daemon/src/__tests__/pr-cron.test.ts
@@ -323,6 +323,11 @@ vi.mock("../sentry.js", () => ({
 // Mock actions to avoid real execFile calls
 vi.mock("../actions.js", () => ({
   detect_review_outcome: vi.fn().mockResolvedValue("approved"),
+  // Default to "approved" via formal review; tests that exercise the
+  // changes-requested branch override per-test with mockResolvedValueOnce.
+  detect_review_outcome_with_source: vi
+    .fn()
+    .mockResolvedValue({ outcome: "approved", source: "review" }),
 }));
 
 // Mock review-utils for retry_approved_unmerged and spawn_ci_fixer tests
@@ -334,6 +339,11 @@ vi.mock("../review-utils.js", () => ({
   fetch_ci_failure_logs: vi.fn().mockResolvedValue([]),
   build_ci_fix_prompt: vi.fn().mockReturnValue("ci fix prompt"),
   MAX_CI_FIX_ATTEMPTS: 3,
+  // Findings-comment cycle-cap helpers (#46). Real bodies are unit-tested in
+  // review-utils.test.ts; here we just keep imports defined.
+  get_authenticated_login: vi.fn().mockResolvedValue("reviewer-bot"),
+  count_verdict_comments: vi.fn().mockResolvedValue(0),
+  count_reviews_by_login: vi.fn().mockResolvedValue(0),
 }));
 
 function make_entity_with_repo(repo_path: string): EntityConfig {
@@ -749,7 +759,10 @@ describe("PRReviewCron.retry_approved_unmerged", () => {
 
     await call_retry(entity_id, repo_path, [pr], entity_config);
 
-    expect(mock_detect_outcome).toHaveBeenCalledWith(42, repo_path, "ghs_test_token");
+    expect(mock_detect_outcome).toHaveBeenCalledWith(42, repo_path, {
+      gh_token: "ghs_test_token",
+      is_self_authored: true,
+    });
     expect(mock_auto_merge).toHaveBeenCalled();
   });
 
@@ -1092,5 +1105,183 @@ describe("PRReviewCron.spawn_ci_fixer", () => {
 
     const result = await call_spawn_ci_fixer(entity_id, repo_path, pr, ["Build"], entity_config);
     expect(result).toBe(true);
+  });
+});
+
+// ── Cycle-cap enforcement (#46) ──
+
+import { MAX_REVIEW_CYCLES } from "../pr-cron.js";
+
+/**
+ * Build a cron instance with `count_review_cycles` overridden to a deterministic
+ * value, and `spawn_external_pr_fixer` stubbed so the test asserts on whether
+ * it was called without spawning a real session.
+ *
+ * The cycle-cap branch fires inside `handle_review_completion` for a
+ * `changes_requested` outcome, so the test drives that method directly.
+ */
+function make_cycle_cap_test_cron(opts: {
+  cycles: number;
+  processed?: Record<string, ProcessedPR>;
+}): {
+  cron: PRReviewCron;
+  alert_router: ReturnType<typeof make_mock_alert_router>;
+  spawn_fixer: ReturnType<typeof vi.fn>;
+  get_processed: () => Record<string, ProcessedPR>;
+  call_handle: (
+    entity_id: string,
+    repo_path: string,
+    pr: TestOpenPR,
+    outcome: "changes_requested" | "approved",
+    verdict_source?: "review" | "comment",
+  ) => Promise<void>;
+} {
+  const config = make_config();
+  const alert_router = make_mock_alert_router();
+  const entity_config = make_entity_with_github_user("test-user");
+  const registry = {
+    get_active: () => [],
+    get: vi.fn().mockReturnValue(entity_config),
+  };
+  const cron = new PRReviewCron(
+    registry as never,
+    { spawn: vi.fn(), on: vi.fn(), removeListener: vi.fn() } as never,
+    config,
+    null,
+    null,
+    null,
+    alert_router as never,
+  );
+
+  const cron_any = cron as unknown as Record<string, unknown>;
+
+  // Replace count_review_cycles with a deterministic counter so we can drive
+  // the cap branch without stubbing `gh`.
+  cron_any.count_review_cycles = vi.fn().mockResolvedValue(opts.cycles);
+
+  // Stub spawn_external_pr_fixer so changes_requested under the cap doesn't
+  // try to actually spawn a builder session.
+  const spawn_fixer = vi.fn().mockResolvedValue(undefined);
+  cron_any.spawn_external_pr_fixer = spawn_fixer;
+
+  // Seed processed state if provided.
+  if (opts.processed) {
+    cron_any.processed = { ...opts.processed };
+  }
+
+  return {
+    cron,
+    alert_router,
+    spawn_fixer,
+    get_processed: () => cron_any.processed as Record<string, ProcessedPR>,
+    call_handle: (entity_id, repo_path, pr, outcome, verdict_source) =>
+      (
+        cron_any.handle_review_completion as (
+          entity_id: string,
+          repo_path: string,
+          pr: TestOpenPR,
+          review_outcome: "changes_requested" | "approved",
+          gh_token: string | undefined,
+          verdict_source: "review" | "comment" | undefined,
+        ) => Promise<void>
+      ).call(cron, entity_id, repo_path, pr, outcome, undefined, verdict_source),
+  };
+}
+
+describe("PRReviewCron — cycle cap (#46)", () => {
+  let log_spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    log_spy.mockRestore();
+  });
+
+  const entity_id = "test-entity";
+  const repo_path = "/tmp/test-repo";
+
+  it("exposes MAX_REVIEW_CYCLES = 3 (spec contract)", () => {
+    expect(MAX_REVIEW_CYCLES).toBe(3);
+  });
+
+  it("at 2 cycles, spawns builder and does not alert", async () => {
+    const pr = make_test_pr({ author: { login: "test-user" } });
+    const { alert_router, spawn_fixer, call_handle, get_processed } = make_cycle_cap_test_cron({
+      cycles: 2,
+    });
+
+    await call_handle(entity_id, repo_path, pr, "changes_requested", "comment");
+
+    // Under the cap → builder is spawned.
+    expect(spawn_fixer).toHaveBeenCalledTimes(1);
+
+    // The alert that fires is the routine "spawning builder" notice, NOT
+    // the action_required cap-hit escalation.
+    expect(alert_router.post_alert).toHaveBeenCalledTimes(1);
+    const call = alert_router.post_alert.mock.calls[0]?.[0] as {
+      tier: string;
+      body: string;
+    };
+    expect(call?.tier).toBe("routine");
+    expect(call?.body).toContain("spawning builder");
+    expect(call?.body).toContain("cycle 2/3");
+
+    // No escalated_at_cycle persisted.
+    expect(get_processed()[`${entity_id}:42`]?.escalated_at_cycle).toBeUndefined();
+  });
+
+  it("at 3 cycles, fires action_required alert and does NOT spawn builder", async () => {
+    const pr = make_test_pr({ author: { login: "test-user" } });
+    const { alert_router, spawn_fixer, call_handle, get_processed } = make_cycle_cap_test_cron({
+      cycles: 3,
+    });
+
+    await call_handle(entity_id, repo_path, pr, "changes_requested", "comment");
+
+    // At the cap → builder NOT spawned.
+    expect(spawn_fixer).not.toHaveBeenCalled();
+
+    // Exactly one action_required alert about the cap.
+    expect(alert_router.post_alert).toHaveBeenCalledTimes(1);
+    const call = alert_router.post_alert.mock.calls[0]?.[0] as {
+      tier: string;
+      title: string;
+      body: string;
+    };
+    expect(call?.tier).toBe("action_required");
+    expect(call?.title).toContain("max review cycles");
+    expect(call?.title).toContain("#42");
+    expect(call?.body).toContain("Hunter");
+
+    // escalated_at_cycle persisted so the next tick stays quiet.
+    expect(get_processed()[`${entity_id}:42`]?.escalated_at_cycle).toBe(3);
+    expect(get_processed()[`${entity_id}:42`]?.verdict_source).toBe("comment");
+  });
+
+  it("does not re-alert on subsequent cron ticks once escalated_at_cycle is set", async () => {
+    const pr = make_test_pr({ author: { login: "test-user" } });
+    const { alert_router, spawn_fixer, call_handle } = make_cycle_cap_test_cron({
+      cycles: 3,
+      processed: {
+        [`${entity_id}:42`]: {
+          entity_id,
+          pr_number: 42,
+          reviewed_at: "2026-05-09T10:00:00Z",
+          outcome: "changes_requested",
+          escalated_at_cycle: 3,
+          verdict_source: "comment",
+        },
+      },
+    });
+
+    await call_handle(entity_id, repo_path, pr, "changes_requested", "comment");
+
+    // Already escalated → no alert, no spawn.
+    expect(alert_router.post_alert).not.toHaveBeenCalled();
+    expect(spawn_fixer).not.toHaveBeenCalled();
   });
 });

--- a/packages/daemon/src/__tests__/review-utils.test.ts
+++ b/packages/daemon/src/__tests__/review-utils.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests for findings-comment verdict detection helpers in review-utils.ts (#46).
+ *
+ * In single-dev repos GitHub blocks `gh pr review --approve` on self-authored
+ * PRs, so Reviewer falls back to posting a regular comment whose first line is
+ * `**Verdict: Approved**` or `**Verdict: Changes Requested**`. These helpers
+ * give the daemon a way to read those comments and count cycles.
+ *
+ * External I/O (execFile) is mocked with the same promisify.custom shim as
+ * actions.test.ts, so we can assert exactly which gh calls are made.
+ */
+
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Module-level mocks ──
+
+const exec_calls: Array<{
+  command: string;
+  args: string[];
+  options?: Record<string, unknown>;
+}> = [];
+
+let exec_mock_impl: (
+  cmd: string,
+  args: string[],
+  opts?: Record<string, unknown>,
+) => Promise<{ stdout: string; stderr: string }>;
+
+vi.mock("node:child_process", () => {
+  const mock_exec_file = vi.fn(
+    (
+      cmd: string,
+      args: string[],
+      opts: Record<string, unknown> | undefined,
+      cb?: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      exec_calls.push({ command: cmd, args, options: opts });
+      if (typeof cb === "function") {
+        exec_mock_impl(cmd, args, opts)
+          .then(({ stdout, stderr }) => cb(null, stdout, stderr))
+          .catch((err: Error) => cb(err, "", ""));
+      }
+    },
+  );
+
+  (mock_exec_file as unknown as { [k: symbol]: unknown })[promisify.custom] = (
+    cmd: string,
+    args: string[],
+    opts?: Record<string, unknown>,
+  ) => {
+    exec_calls.push({ command: cmd, args, options: opts });
+    return exec_mock_impl(cmd, args, opts);
+  };
+
+  return {
+    execFile: mock_exec_file,
+    exec: vi.fn(),
+  };
+});
+
+// ── Imports (after mocks) ──
+
+import {
+  count_reviews_by_login,
+  count_verdict_comments,
+  detect_verdict_from_comments,
+  get_authenticated_login,
+} from "../review-utils.js";
+
+// ── Helpers ──
+
+interface Comment {
+  body: string;
+  createdAt: string;
+  author: { login: string } | null;
+}
+
+/**
+ * Configure the exec mock so that:
+ *   - `gh api user` resolves to `login`
+ *   - `gh pr view <n> --json comments` resolves to `comments` (JSON-encoded)
+ *   - `gh pr view <n> --json reviews` resolves to `reviews` (JSON-encoded)
+ */
+function set_gh_responses(opts: {
+  login?: string;
+  comments?: Comment[];
+  reviews?: Array<{ author: { login: string } | null; state?: string }>;
+  comments_error?: Error;
+  reviews_error?: Error;
+  login_error?: Error;
+}) {
+  exec_mock_impl = async (_cmd, args) => {
+    if (args[0] === "api" && args[1] === "user") {
+      if (opts.login_error) throw opts.login_error;
+      return { stdout: opts.login ?? "", stderr: "" };
+    }
+    if (args.includes("--json") && args.includes("comments")) {
+      if (opts.comments_error) throw opts.comments_error;
+      return { stdout: JSON.stringify(opts.comments ?? []), stderr: "" };
+    }
+    if (args.includes("--json") && args.includes("reviews")) {
+      if (opts.reviews_error) throw opts.reviews_error;
+      return { stdout: JSON.stringify(opts.reviews ?? []), stderr: "" };
+    }
+    return { stdout: "", stderr: "" };
+  };
+}
+
+const REPO = "/repos/test-repo";
+const REVIEWER = "reviewer-bot";
+
+beforeEach(() => {
+  exec_calls.length = 0;
+  exec_mock_impl = async () => ({ stdout: "", stderr: "" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── detect_verdict_from_comments ──
+
+describe("detect_verdict_from_comments", () => {
+  it("returns Approved when latest comment matches the approved prefix", async () => {
+    set_gh_responses({
+      comments: [
+        {
+          body: "**Verdict: Approved**\n\nLooks good!",
+          createdAt: "2026-05-09T10:00:00Z",
+          author: { login: REVIEWER },
+        },
+      ],
+    });
+
+    const result = await detect_verdict_from_comments(42, REPO, REVIEWER);
+    expect(result).toEqual({ verdict: "approved", created_at: "2026-05-09T10:00:00Z" });
+  });
+
+  it("returns Changes Requested when latest comment matches that prefix", async () => {
+    set_gh_responses({
+      comments: [
+        {
+          body: "**Verdict: Changes Requested**\n\nFix the foo.",
+          createdAt: "2026-05-09T10:00:00Z",
+          author: { login: REVIEWER },
+        },
+      ],
+    });
+
+    const result = await detect_verdict_from_comments(42, REPO, REVIEWER);
+    expect(result).toEqual({
+      verdict: "changes_requested",
+      created_at: "2026-05-09T10:00:00Z",
+    });
+  });
+
+  it("returns null when no comment matches the verdict format", async () => {
+    set_gh_responses({
+      comments: [
+        {
+          body: "Just a regular comment, no verdict here.",
+          createdAt: "2026-05-09T10:00:00Z",
+          author: { login: REVIEWER },
+        },
+        {
+          body: "Verdict: Approved", // missing the bold markers
+          createdAt: "2026-05-09T11:00:00Z",
+          author: { login: REVIEWER },
+        },
+        {
+          body: "  **Verdict: Approved**", // leading whitespace breaks the literal-first-line rule
+          createdAt: "2026-05-09T12:00:00Z",
+          author: { login: REVIEWER },
+        },
+      ],
+    });
+
+    const result = await detect_verdict_from_comments(42, REPO, REVIEWER);
+    expect(result).toBeNull();
+  });
+
+  it("ignores comments authored by anyone other than the authenticated login", async () => {
+    set_gh_responses({
+      comments: [
+        {
+          body: "**Verdict: Approved**\n\nNot the bot.",
+          createdAt: "2026-05-09T10:00:00Z",
+          author: { login: "hkelley44" },
+        },
+        {
+          body: "**Verdict: Changes Requested**\n\nAlso not the bot.",
+          createdAt: "2026-05-09T11:00:00Z",
+          author: null,
+        },
+      ],
+    });
+
+    const result = await detect_verdict_from_comments(42, REPO, REVIEWER);
+    expect(result).toBeNull();
+  });
+
+  it("uses the most recent matching comment when multiple exist", async () => {
+    set_gh_responses({
+      comments: [
+        // Older verdict — should NOT win.
+        {
+          body: "**Verdict: Changes Requested**\n\nFirst pass.",
+          createdAt: "2026-05-09T10:00:00Z",
+          author: { login: REVIEWER },
+        },
+        // Newer verdict, flipping the call. Note: deliberately out of chronological
+        // order in the array so we exercise the timestamp comparison, not array order.
+        {
+          body: "**Verdict: Approved**\n\nAfter the fix.",
+          createdAt: "2026-05-09T12:00:00Z",
+          author: { login: REVIEWER },
+        },
+        // Even newer human comment — but wrong author, must be filtered.
+        {
+          body: "**Verdict: Changes Requested**\n\nHuman noise.",
+          createdAt: "2026-05-09T13:00:00Z",
+          author: { login: "hkelley44" },
+        },
+      ],
+    });
+
+    const result = await detect_verdict_from_comments(42, REPO, REVIEWER);
+    expect(result).toEqual({ verdict: "approved", created_at: "2026-05-09T12:00:00Z" });
+  });
+
+  it("returns null on gh CLI failure", async () => {
+    set_gh_responses({ comments_error: new Error("gh: rate limited") });
+    const result = await detect_verdict_from_comments(42, REPO, REVIEWER);
+    expect(result).toBeNull();
+  });
+});
+
+// ── get_authenticated_login ──
+
+describe("get_authenticated_login", () => {
+  it("returns the trimmed login from `gh api user`", async () => {
+    set_gh_responses({ login: "reviewer-bot\n" });
+    const login = await get_authenticated_login(REPO);
+    expect(login).toBe("reviewer-bot");
+  });
+
+  it("returns null when `gh api user` fails", async () => {
+    set_gh_responses({ login_error: new Error("gh: not authenticated") });
+    const login = await get_authenticated_login(REPO);
+    expect(login).toBeNull();
+  });
+
+  it("returns null when login is empty", async () => {
+    set_gh_responses({ login: "" });
+    const login = await get_authenticated_login(REPO);
+    expect(login).toBeNull();
+  });
+});
+
+// ── count_verdict_comments ──
+
+describe("count_verdict_comments", () => {
+  it("counts only verdict-prefixed comments by the authenticated login", async () => {
+    set_gh_responses({
+      comments: [
+        {
+          body: "**Verdict: Approved**",
+          createdAt: "2026-05-09T10:00:00Z",
+          author: { login: REVIEWER },
+        },
+        {
+          body: "**Verdict: Changes Requested**",
+          createdAt: "2026-05-09T11:00:00Z",
+          author: { login: REVIEWER },
+        },
+        {
+          body: "**Verdict: Changes Requested**",
+          createdAt: "2026-05-09T12:00:00Z",
+          author: { login: "hkelley44" },
+        },
+        {
+          body: "Not a verdict",
+          createdAt: "2026-05-09T13:00:00Z",
+          author: { login: REVIEWER },
+        },
+      ],
+    });
+    const n = await count_verdict_comments(42, REPO, REVIEWER);
+    expect(n).toBe(2);
+  });
+
+  it("returns 0 on gh CLI failure", async () => {
+    set_gh_responses({ comments_error: new Error("gh: boom") });
+    const n = await count_verdict_comments(42, REPO, REVIEWER);
+    expect(n).toBe(0);
+  });
+});
+
+// ── count_reviews_by_login ──
+
+describe("count_reviews_by_login", () => {
+  it("counts only reviews authored by the given login", async () => {
+    set_gh_responses({
+      reviews: [
+        { author: { login: REVIEWER }, state: "APPROVED" },
+        { author: { login: REVIEWER }, state: "CHANGES_REQUESTED" },
+        { author: { login: "external-contributor" }, state: "COMMENTED" },
+        { author: null, state: "DISMISSED" },
+      ],
+    });
+    const n = await count_reviews_by_login(42, REPO, REVIEWER);
+    expect(n).toBe(2);
+  });
+
+  it("returns 0 on gh CLI failure", async () => {
+    set_gh_responses({ reviews_error: new Error("gh: boom") });
+    const n = await count_reviews_by_login(42, REPO, REVIEWER);
+    expect(n).toBe(0);
+  });
+});

--- a/packages/daemon/src/__tests__/webhook-handler.test.ts
+++ b/packages/daemon/src/__tests__/webhook-handler.test.ts
@@ -1298,7 +1298,7 @@ describe("handle_github_webhook", () => {
         expect(detect_review_outcome).toHaveBeenCalledWith(
           950,
           "/tmp/test-repo",
-          "ghs_install_88888",
+          expect.objectContaining({ gh_token: "ghs_install_88888" }),
         );
       } finally {
         log_spy.mockRestore();
@@ -1342,7 +1342,11 @@ describe("handle_github_webhook", () => {
         );
 
         // Default token from get_token() is "ghs_mock_token"
-        expect(detect_review_outcome).toHaveBeenCalledWith(951, "/tmp/test-repo", "ghs_mock_token");
+        expect(detect_review_outcome).toHaveBeenCalledWith(
+          951,
+          "/tmp/test-repo",
+          expect.objectContaining({ gh_token: "ghs_mock_token" }),
+        );
       } finally {
         log_spy.mockRestore();
       }
@@ -1396,10 +1400,151 @@ describe("handle_github_webhook", () => {
         );
 
         // Token should be undefined since resolution failed
-        expect(detect_review_outcome).toHaveBeenCalledWith(952, "/tmp/test-repo", undefined);
+        expect(detect_review_outcome).toHaveBeenCalledWith(
+          952,
+          "/tmp/test-repo",
+          expect.objectContaining({ gh_token: undefined }),
+        );
       } finally {
         log_spy.mockRestore();
         error_spy.mockRestore();
+      }
+    });
+
+    // Regression: webhook path must opt into the findings-comment fallback for
+    // self-authored PRs (#46 cycle 2). detect_review_outcome silently degrades
+    // to `pending` when `is_self_authored` is absent, so the comment fallback
+    // is dead for any PR routed through the webhook unless we wire it.
+    it("passes is_self_authored=true when PR author matches entity's GitHub user", async () => {
+      const { detect_review_outcome } = await import("../actions.js");
+      const log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      try {
+        // PR author "lobster-bot" matches the entity's github user.
+        const body = make_pr_payload("opened", 9460, "test-org/lobster-farm", {
+          user: { login: "lobster-bot" },
+        });
+        const req = make_request(body, {
+          "x-github-event": "pull_request",
+          "x-hub-signature-256": sign_payload(body),
+        });
+        const res = make_response();
+
+        // Custom registry where the entity exposes its GitHub user.
+        const registry = {
+          get_active: vi.fn().mockReturnValue([
+            {
+              entity: {
+                id: "lobster-farm",
+                accounts: { github: { user: "lobster-bot" } },
+                repos: [
+                  {
+                    name: "lobster-farm",
+                    url: "https://github.com/test-org/lobster-farm.git",
+                    path: "/tmp/test-repo",
+                  },
+                ],
+              },
+            },
+          ]),
+        } as unknown as EntityRegistry;
+        const ctx = make_context({ registry });
+
+        await handle_github_webhook(req, res, ctx);
+
+        await vi.waitFor(
+          () => {
+            expect((ctx.session_manager as any).spawn).toHaveBeenCalledTimes(1);
+          },
+          { timeout: 2000 },
+        );
+
+        const spawn_result = await (ctx.session_manager as any).spawn.mock.results[0].value;
+        (ctx.session_manager as any).emit("session:completed", {
+          session_id: spawn_result.session_id,
+          exit_code: 0,
+        });
+
+        await vi.waitFor(
+          () => {
+            expect(detect_review_outcome).toHaveBeenCalled();
+          },
+          { timeout: 2000 },
+        );
+
+        expect(detect_review_outcome).toHaveBeenCalledWith(
+          9460,
+          "/tmp/test-repo",
+          expect.objectContaining({ is_self_authored: true }),
+        );
+      } finally {
+        log_spy.mockRestore();
+      }
+    });
+
+    it("passes is_self_authored=false when PR author does not match entity's GitHub user", async () => {
+      const { detect_review_outcome } = await import("../actions.js");
+      const log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      try {
+        // PR author "external-contributor" does NOT match the entity's user.
+        const body = make_pr_payload("opened", 9461, "test-org/lobster-farm", {
+          user: { login: "external-contributor" },
+        });
+        const req = make_request(body, {
+          "x-github-event": "pull_request",
+          "x-hub-signature-256": sign_payload(body),
+        });
+        const res = make_response();
+
+        const registry = {
+          get_active: vi.fn().mockReturnValue([
+            {
+              entity: {
+                id: "lobster-farm",
+                accounts: { github: { user: "lobster-bot" } },
+                repos: [
+                  {
+                    name: "lobster-farm",
+                    url: "https://github.com/test-org/lobster-farm.git",
+                    path: "/tmp/test-repo",
+                  },
+                ],
+              },
+            },
+          ]),
+        } as unknown as EntityRegistry;
+        const ctx = make_context({ registry });
+
+        await handle_github_webhook(req, res, ctx);
+
+        await vi.waitFor(
+          () => {
+            expect((ctx.session_manager as any).spawn).toHaveBeenCalledTimes(1);
+          },
+          { timeout: 2000 },
+        );
+
+        const spawn_result = await (ctx.session_manager as any).spawn.mock.results[0].value;
+        (ctx.session_manager as any).emit("session:completed", {
+          session_id: spawn_result.session_id,
+          exit_code: 0,
+        });
+
+        await vi.waitFor(
+          () => {
+            expect(detect_review_outcome).toHaveBeenCalled();
+          },
+          { timeout: 2000 },
+        );
+
+        expect(detect_review_outcome).toHaveBeenCalledWith(
+          9461,
+          "/tmp/test-repo",
+          expect.objectContaining({ is_self_authored: false }),
+        );
+      } finally {
+        log_spy.mockRestore();
       }
     });
   });

--- a/packages/daemon/src/actions.ts
+++ b/packages/daemon/src/actions.ts
@@ -29,6 +29,7 @@ import { entity_config_path, expand_home, write_yaml } from "@lobster-farm/share
 import { is_discord_snowflake } from "./discord.js";
 import type { DiscordBot } from "./discord.js";
 import type { BotPool } from "./pool.js";
+import { detect_verdict_from_comments, get_authenticated_login } from "./review-utils.js";
 import * as sentry from "./sentry.js";
 
 const exec = promisify(execFile);
@@ -351,24 +352,78 @@ export async function release_work_room(
 // ── Review outcome detection ──
 
 export type ReviewOutcome = "approved" | "changes_requested" | "dismissed" | "pending";
+export type ReviewOutcomeSource = "review" | "comment";
+
+export interface ReviewOutcomeResult {
+  outcome: ReviewOutcome;
+  /** Where the outcome came from. Useful for diagnostics + persisted on `ProcessedPR`. */
+  source: ReviewOutcomeSource;
+}
+
+/**
+ * Options for `detect_review_outcome` (#46).
+ *
+ * - `gh_token`: GitHub token for cross-account authentication. Without this,
+ *   `gh` inherits the daemon's default auth.
+ * - `is_self_authored`: when true and `reviewDecision` is empty, fall back to
+ *   parsing findings-comment verdicts. Single-dev repos block
+ *   `gh pr review --approve` on self-authored PRs, so Reviewer posts comments
+ *   with `**Verdict: Approved**` / `**Verdict: Changes Requested**` instead.
+ *   The caller decides what counts as self-authored (typically
+ *   `pr.author.login === entity.accounts.github.user`).
+ */
+export interface DetectReviewOutcomeOptions {
+  gh_token?: string;
+  is_self_authored?: boolean;
+}
 
 /**
  * Detect the review outcome for a PR by querying GitHub.
+ *
  * Returns "approved", "changes_requested", "dismissed", or "pending".
  * An already-merged PR is treated as "approved".
  * A "dismissed" outcome means all reviews were dismissed (e.g., duplicate
  * cleanup) — the caller should trigger a fresh review.
  *
- * @param gh_token - Optional GitHub token for cross-account authentication.
- *   Without this, `gh` inherits the daemon's default auth, which can't see
- *   private repos on other GitHub accounts.
+ * Resolution order (#46):
+ *   1. PR state == MERGED → approved (source: "review")
+ *   2. `reviewDecision` is APPROVED / CHANGES_REQUESTED / DISMISSED → use it
+ *      (source: "review")
+ *   3. `reviewDecision` is empty AND `is_self_authored` is true → poll
+ *      `gh pr view --json comments` for findings-comment verdicts authored by
+ *      the daemon's `gh api user` login (source: "comment")
+ *   4. Otherwise → pending (source: "review")
+ *
+ * The comment-fallback path is intentionally gated on `is_self_authored`: in
+ * multi-dev repos formal reviews work, so we don't open a side channel that
+ * could shadow the official decision.
  */
 export async function detect_review_outcome(
   pr_number: number,
   repo_path: string,
-  gh_token?: string,
+  gh_token_or_opts?: string | DetectReviewOutcomeOptions,
 ): Promise<ReviewOutcome> {
-  const env = gh_token ? { GH_TOKEN: gh_token } : undefined;
+  const result = await detect_review_outcome_with_source(pr_number, repo_path, gh_token_or_opts);
+  return result.outcome;
+}
+
+/**
+ * Variant that also returns where the outcome came from (`"review"` vs
+ * `"comment"`). Persisted on `ProcessedPR.verdict_source` so a future debugging
+ * session can see at a glance whether the daemon read a formal review or a
+ * findings-comment fallback.
+ */
+export async function detect_review_outcome_with_source(
+  pr_number: number,
+  repo_path: string,
+  gh_token_or_opts?: string | DetectReviewOutcomeOptions,
+): Promise<ReviewOutcomeResult> {
+  const opts: DetectReviewOutcomeOptions =
+    typeof gh_token_or_opts === "string" || gh_token_or_opts === undefined
+      ? { gh_token: gh_token_or_opts }
+      : gh_token_or_opts;
+
+  const env = opts.gh_token ? { GH_TOKEN: opts.gh_token } : undefined;
 
   try {
     // Check if PR is already merged
@@ -380,7 +435,7 @@ export async function detect_review_outcome(
     );
 
     if (state === "MERGED") {
-      return "approved";
+      return { outcome: "approved", source: "review" };
     }
 
     // Check review decision
@@ -393,14 +448,38 @@ export async function detect_review_outcome(
 
     switch (decision.toUpperCase()) {
       case "APPROVED":
-        return "approved";
+        return { outcome: "approved", source: "review" };
       case "CHANGES_REQUESTED":
-        return "changes_requested";
+        return { outcome: "changes_requested", source: "review" };
       case "DISMISSED":
-        return "dismissed";
-      default:
-        return "pending";
+        return { outcome: "dismissed", source: "review" };
     }
+
+    // reviewDecision is empty. In single-dev / self-authored mode, Reviewer
+    // can't post a formal review via `gh pr review --approve` — GitHub blocks
+    // self-review. Fall back to the findings-comment verdict format (#46).
+    if (opts.is_self_authored) {
+      // Resolve the daemon's effective GitHub login. We MUST be able to
+      // identify the author before trusting any comment-based verdict;
+      // otherwise a stray human comment could be misread as a Reviewer call.
+      const login = await get_authenticated_login(repo_path, env);
+      if (login) {
+        // Pass the merged env (process.env + GH_TOKEN) so the gh CLI invocation
+        // inside detect_verdict_from_comments sees the override token too.
+        const merged_env = env ? { ...process.env, ...env } : undefined;
+        const detection = await detect_verdict_from_comments(
+          pr_number,
+          repo_path,
+          login,
+          merged_env,
+        );
+        if (detection) {
+          return { outcome: detection.verdict, source: "comment" };
+        }
+      }
+    }
+
+    return { outcome: "pending", source: "review" };
   } catch (err) {
     console.error(
       `[actions] Failed to detect review outcome for PR #${String(pr_number)}: ${String(err)}`,
@@ -409,7 +488,7 @@ export async function detect_review_outcome(
       tags: { module: "actions", action: "detect_review_outcome" },
       contexts: { pr: { number: pr_number } },
     });
-    return "pending";
+    return { outcome: "pending", source: "review" };
   }
 }
 

--- a/packages/daemon/src/actions.ts
+++ b/packages/daemon/src/actions.ts
@@ -423,7 +423,14 @@ export async function detect_review_outcome_with_source(
       ? { gh_token: gh_token_or_opts }
       : gh_token_or_opts;
 
+  // `env` is what we pass to `run()` (the local helper merges with process.env
+  // internally — see line 49). `merged_env` is what we pass to direct
+  // `exec_async` callers in review-utils.ts (get_authenticated_login,
+  // detect_verdict_from_comments) which do NOT merge themselves — without this
+  // PATH is dropped and the `gh` binary cannot be located. Build once and
+  // reuse so the two paths can't drift apart again.
   const env = opts.gh_token ? { GH_TOKEN: opts.gh_token } : undefined;
+  const merged_env = env ? { ...process.env, ...env } : undefined;
 
   try {
     // Check if PR is already merged
@@ -462,11 +469,8 @@ export async function detect_review_outcome_with_source(
       // Resolve the daemon's effective GitHub login. We MUST be able to
       // identify the author before trusting any comment-based verdict;
       // otherwise a stray human comment could be misread as a Reviewer call.
-      const login = await get_authenticated_login(repo_path, env);
+      const login = await get_authenticated_login(repo_path, merged_env);
       if (login) {
-        // Pass the merged env (process.env + GH_TOKEN) so the gh CLI invocation
-        // inside detect_verdict_from_comments sees the override token too.
-        const merged_env = env ? { ...process.env, ...env } : undefined;
         const detection = await detect_verdict_from_comments(
           pr_number,
           repo_path,

--- a/packages/daemon/src/persistence.ts
+++ b/packages/daemon/src/persistence.ts
@@ -44,6 +44,14 @@ export interface ProcessedPR {
    * Incremented each time a builder is spawned to fix CI failures.
    * Reset when new commits arrive from a non-builder source. (#196) */
   ci_fix_attempts?: number;
+  /** Diagnostic-only: where the last review outcome came from (#46).
+   * "review" = formal `PullRequestReview` via `reviewDecision`.
+   * "comment" = findings-comment fallback in single-dev repos. */
+  verdict_source?: "review" | "comment";
+  /** Cycle index at which we escalated to #alerts for hitting the review
+   * cycle cap (#46). Set so subsequent cron ticks don't re-alert for the
+   * same cap-hit state. */
+  escalated_at_cycle?: number;
 
   // ── v2 PR lifecycle (#257) ──
   /** Last head SHA the v2 check-suite-handler dispatched on.

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -3,7 +3,12 @@ import { stat } from "node:fs/promises";
 import { promisify } from "node:util";
 import type { EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
 import { expand_home } from "@lobster-farm/shared";
-import { type ReviewOutcome, detect_review_outcome } from "./actions.js";
+import {
+  type ReviewOutcome,
+  type ReviewOutcomeSource,
+  detect_review_outcome,
+  detect_review_outcome_with_source,
+} from "./actions.js";
 import { ALERT_COLOR_AMBER, type AlertRouter } from "./alert-router.js";
 import type { DiscordBot } from "./discord.js";
 import { resolve_binary } from "./env.js";
@@ -24,8 +29,11 @@ import {
   build_ci_fix_prompt,
   build_review_fix_prompt,
   check_ci_status,
+  count_reviews_by_login,
+  count_verdict_comments,
   fetch_ci_failure_logs,
   fetch_review_comments,
+  get_authenticated_login,
 } from "./review-utils.js";
 import * as sentry from "./sentry.js";
 import type { ClaudeSessionManager } from "./session.js";
@@ -107,6 +115,15 @@ const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 /** Buffer in ms to avoid re-reviewing when commit and review timestamps are very close. */
 const TIMESTAMP_BUFFER_MS = 60_000; // 60 seconds
+
+/**
+ * Hard cap on review→fix cycles per PR before escalating to a human (#46).
+ *
+ * Matches the spec amendment on issue #38 — three swings at the bat. When the
+ * counter reaches this value, the daemon stops spawning Builder and instead
+ * posts an amber alert. Configurability per-repo is v2.
+ */
+export const MAX_REVIEW_CYCLES = 3;
 
 export class PRReviewCron {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -557,7 +574,17 @@ export class PRReviewCron {
     // authenticate against the correct GitHub account (cross-account repos).
     const gh_token = await this.resolve_entity_token(entity_config);
 
-    const outcome = await detect_review_outcome(pr.number, repo_path, gh_token);
+    // In single-dev repos GitHub blocks `gh pr review --approve` on
+    // self-authored PRs, so Reviewer falls back to a `**Verdict:` comment.
+    // We pass `is_self_authored` so detect_review_outcome can poll comments
+    // when reviewDecision is empty. See #46.
+    const github_user = entity_config.entity.accounts?.github?.user;
+    const is_self_authored = github_user != null && pr.author.login === github_user;
+
+    const { outcome, source } = await detect_review_outcome_with_source(pr.number, repo_path, {
+      gh_token,
+      is_self_authored,
+    });
 
     // Don't persist "dismissed" — the dedup check (`pr.updatedAt <= prior.reviewed_at`)
     // would skip the PR on the next cycle, breaking the "will be re-reviewed" promise.
@@ -566,21 +593,25 @@ export class PRReviewCron {
       console.log(
         `[pr-cron] Dismissed outcome for PR #${String(pr.number)} — not persisting, will re-review next cycle`,
       );
-      await this.handle_review_completion(entity_id, repo_path, pr, outcome, gh_token);
+      await this.handle_review_completion(entity_id, repo_path, pr, outcome, gh_token, source);
       return;
     }
 
     this.processed[key] = {
+      ...(this.processed[key] ?? {}),
       entity_id,
       pr_number: pr.number,
       reviewed_at: new Date().toISOString(),
       outcome,
+      verdict_source: source,
     };
     await save_pr_reviews(this.processed, this.config);
-    console.log(`[pr-cron] Persisted review for PR #${String(pr.number)} (${outcome})`);
+    console.log(
+      `[pr-cron] Persisted review for PR #${String(pr.number)} (${outcome}, source=${source})`,
+    );
 
     // Route the outcome (alerts, fix spawning, etc.)
-    await this.handle_review_completion(entity_id, repo_path, pr, outcome, gh_token);
+    await this.handle_review_completion(entity_id, repo_path, pr, outcome, gh_token, source);
   }
 
   /** After a reviewer session completes, detect the outcome and route accordingly. */
@@ -590,23 +621,73 @@ export class PRReviewCron {
     pr: OpenPR,
     review_outcome?: ReviewOutcome,
     gh_token?: string,
+    verdict_source?: ReviewOutcomeSource,
   ): Promise<void> {
-    const review_state =
-      review_outcome ?? (await detect_review_outcome(pr.number, repo_path, gh_token));
-
     // Determine if internal (our agents) or truly external
     const entity_config = this.registry.get(entity_id);
     const github_user = entity_config?.entity.accounts?.github?.user;
     const is_internal = github_user != null && pr.author.login === github_user;
 
+    let review_state: ReviewOutcome;
+    if (review_outcome) {
+      review_state = review_outcome;
+    } else {
+      review_state = await detect_review_outcome(pr.number, repo_path, {
+        gh_token,
+        is_self_authored: is_internal,
+      });
+    }
+
     if (review_state === "changes_requested") {
+      // Enforce the per-PR review-cycle cap (#46). Single-dev repos count
+      // findings-comment verdicts; multi-dev repos count formal reviews by
+      // the daemon's login. The latter mirrors today's mental model and is
+      // a strict subset of "all reviews" — we only count Reviewer's passes.
+      const cycles = await this.count_review_cycles(pr.number, repo_path, is_internal, gh_token);
+      const key = `${entity_id}:${String(pr.number)}`;
+      const already_escalated = this.processed[key]?.escalated_at_cycle != null;
+
+      if (cycles >= MAX_REVIEW_CYCLES) {
+        // Don't spawn a Builder — escalate. Persist `escalated_at_cycle` so
+        // the next cron tick sees we already alerted and stays quiet.
+        if (!already_escalated) {
+          await this.alert_router?.post_alert({
+            entity_id,
+            tier: "action_required",
+            title: `\u26a0\ufe0f PR #${String(pr.number)} hit max review cycles (${String(MAX_REVIEW_CYCLES)})`,
+            body: `${pr.title}\nVerdict: Changes Requested (cycle ${String(cycles)}/${String(MAX_REVIEW_CYCLES)})\n${pr.url}\nNeeds human pickup — paging Hunter.`,
+            embed_color: ALERT_COLOR_AMBER,
+          });
+          this.processed[key] = {
+            ...(this.processed[key] ?? {
+              entity_id,
+              pr_number: pr.number,
+              reviewed_at: new Date().toISOString(),
+              outcome: "changes_requested" as const,
+            }),
+            outcome: "changes_requested",
+            ...(verdict_source ? { verdict_source } : {}),
+            escalated_at_cycle: cycles,
+          };
+          await save_pr_reviews(this.processed, this.config);
+          console.log(
+            `[pr-cron] PR #${String(pr.number)} hit cycle cap (${String(cycles)}/${String(MAX_REVIEW_CYCLES)}) — escalated, not spawning builder`,
+          );
+        } else {
+          console.log(
+            `[pr-cron] PR #${String(pr.number)} already escalated at cycle ${String(this.processed[key]?.escalated_at_cycle)} — staying quiet`,
+          );
+        }
+        return;
+      }
+
       await this.spawn_external_pr_fixer(entity_id, repo_path, pr, entity_config);
       const prefix = is_internal ? "" : `External (from @${pr.author.login}) `;
       await this.alert_router?.post_alert({
         entity_id,
         tier: "routine",
         title: `${prefix}PR #${String(pr.number)} changes requested`,
-        body: `${pr.title} — spawning builder to fix`,
+        body: `${pr.title} — spawning builder to fix (cycle ${String(cycles)}/${String(MAX_REVIEW_CYCLES)})`,
       });
     } else if (review_state === "approved") {
       // Check if the reviewer already merged (they're instructed to merge on approval)
@@ -749,8 +830,13 @@ export class PRReviewCron {
         // PR-cron path: we already know the outcome from the previous review
         is_approved = true;
       } else if (!processed_entry) {
-        // Webhook handler path: no processed entry, check GitHub directly
-        const outcome = await detect_review_outcome(pr.number, repo_path, gh_token);
+        // Webhook handler path: no processed entry, check GitHub directly.
+        // Mirror persist_review_completion's is_self_authored signal so the
+        // findings-comment fallback (#46) fires when applicable.
+        const outcome = await detect_review_outcome(pr.number, repo_path, {
+          gh_token,
+          is_self_authored: is_internal,
+        });
         if (outcome === "approved") {
           is_approved = true;
         }
@@ -1053,6 +1139,37 @@ export class PRReviewCron {
   }
 
   // notify_alerts removed — all call sites migrated to this.alert_router.post_alert()
+
+  /**
+   * Count review cycles for cycle-cap enforcement (#46).
+   *
+   * - Single-dev / self-authored: count findings-comment verdicts authored by
+   *   the daemon's `gh api user` login (the same login Reviewer posts as).
+   * - Multi-dev / external: count formal `PullRequestReview` objects by that
+   *   same login.
+   *
+   * Returns 0 when the authenticated login cannot be resolved — under-counting
+   * is safer than over-counting: an extra Builder spawn is cheap, a missed cap
+   * means an infinite loop.
+   *
+   * Visibility is `protected` so test subclasses can override and inject
+   * deterministic counts without stubbing the gh CLI.
+   */
+  protected async count_review_cycles(
+    pr_number: number,
+    repo_path: string,
+    is_self_authored: boolean,
+    gh_token?: string,
+  ): Promise<number> {
+    const env = gh_token ? { ...process.env, GH_TOKEN: gh_token } : process.env;
+    const login = await get_authenticated_login(repo_path, env, this.gh_bin);
+    if (!login) return 0;
+
+    if (is_self_authored) {
+      return count_verdict_comments(pr_number, repo_path, login, env, this.gh_bin);
+    }
+    return count_reviews_by_login(pr_number, repo_path, login, env, this.gh_bin);
+  }
 
   /** Check if a PR has been merged. */
   private async check_pr_merged(

--- a/packages/daemon/src/review-utils.ts
+++ b/packages/daemon/src/review-utils.ts
@@ -63,6 +63,201 @@ export async function fetch_review_comments(pr_number: number, repo_path: string
   }
 }
 
+// ── Findings-comment verdict detection (#46) ──
+
+/**
+ * The verdict a reviewer can express in a findings-comment fallback.
+ *
+ * In single-dev repos GitHub blocks `gh pr review --approve` on self-authored
+ * PRs, so Reviewer falls back to posting a regular comment whose first line
+ * is `**Verdict: Approved**` or `**Verdict: Changes Requested**`. The daemon
+ * polls those comments here when GraphQL's `reviewDecision` field is empty.
+ */
+export type CommentVerdict = "approved" | "changes_requested";
+
+interface GHCommentForVerdict {
+  body: string;
+  createdAt: string;
+  author: { login: string } | null;
+}
+
+/** Verdict match shape from `detect_verdict_from_comments`. */
+export interface VerdictDetection {
+  verdict: CommentVerdict;
+  /** ISO timestamp of the comment carrying the verdict. */
+  created_at: string;
+}
+
+/** Format mandated by `pr-review-merge/SKILL.md` — must be the literal first line. */
+const APPROVED_PREFIX = "**Verdict: Approved**";
+const CHANGES_REQUESTED_PREFIX = "**Verdict: Changes Requested**";
+
+/** Extract the verdict from a single comment body, if it matches the mandated format. */
+function verdict_of(body: string): CommentVerdict | null {
+  // Must be the literal first line. Case-sensitive — matches the SKILL spec.
+  // Use indexOf instead of split to avoid allocating the whole array.
+  const first_newline = body.indexOf("\n");
+  const first_line = first_newline === -1 ? body : body.slice(0, first_newline);
+  if (first_line === APPROVED_PREFIX) return "approved";
+  if (first_line === CHANGES_REQUESTED_PREFIX) return "changes_requested";
+  return null;
+}
+
+/**
+ * Resolve the GitHub login that the daemon (and therefore Reviewer in single-dev
+ * mode) authenticates as. Returned login is used to filter comment authors.
+ *
+ * Returns null when `gh api user` fails — the caller should treat that as
+ * "cannot determine fallback verdict" and stay pending rather than risk a
+ * false positive by accepting any author's verdict comment.
+ */
+export async function get_authenticated_login(
+  repo_path: string,
+  env?: NodeJS.ProcessEnv,
+  gh_bin = "gh",
+): Promise<string | null> {
+  try {
+    const { stdout } = await exec_async(gh_bin, ["api", "user", "--jq", ".login"], {
+      cwd: repo_path,
+      env,
+      timeout: 15_000,
+    });
+    const login = stdout.trim();
+    return login || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect the most recent verdict expressed via findings-comment fallback (#46).
+ *
+ * Used in single-dev repos where `gh pr review --approve` is blocked on
+ * self-authored PRs and Reviewer instead posts a comment whose first line is
+ * `**Verdict: Approved**` or `**Verdict: Changes Requested**`.
+ *
+ * Behavior:
+ * - Calls `gh pr view <n> --json comments`
+ * - Filters comments authored by `authenticated_login` (the daemon's
+ *   effective GitHub user — same login Reviewer posts as in single-dev mode)
+ * - Returns the verdict from the **most recent** matching comment whose body
+ *   starts with the mandated literal prefix
+ * - Returns `null` if no qualifying comment exists, or on any gh CLI failure
+ *
+ * Match is case-sensitive and requires the prefix to be the literal first
+ * line — matches the format `pr-review-merge/SKILL.md` mandates.
+ */
+export async function detect_verdict_from_comments(
+  pr_number: number,
+  repo_path: string,
+  authenticated_login: string,
+  env?: NodeJS.ProcessEnv,
+  gh_bin = "gh",
+): Promise<VerdictDetection | null> {
+  let comments: GHCommentForVerdict[];
+  try {
+    const { stdout } = await exec_async(
+      gh_bin,
+      ["pr", "view", String(pr_number), "--json", "comments", "--jq", ".comments"],
+      { cwd: repo_path, env, timeout: 15_000 },
+    );
+    const parsed: unknown = JSON.parse(stdout || "[]");
+    comments = Array.isArray(parsed) ? (parsed as GHCommentForVerdict[]) : [];
+  } catch {
+    return null;
+  }
+
+  let best: VerdictDetection | null = null;
+  let best_ts = -1;
+
+  for (const comment of comments) {
+    if (!comment || typeof comment.body !== "string") continue;
+    if (comment.author?.login !== authenticated_login) continue;
+    const verdict = verdict_of(comment.body);
+    if (!verdict) continue;
+    const ts = new Date(comment.createdAt).getTime();
+    if (Number.isNaN(ts)) continue;
+    if (ts > best_ts) {
+      best_ts = ts;
+      best = { verdict, created_at: comment.createdAt };
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Count comments authored by `authenticated_login` whose body starts with a
+ * verdict prefix. Used to enforce the per-PR review-cycle cap in single-dev
+ * repos (#46). Multi-dev mode counts formal reviews instead — see pr-cron.ts.
+ *
+ * Returns 0 on any gh CLI failure (we'd rather under-count and spawn an extra
+ * Builder than over-count and silently stall the loop).
+ */
+export async function count_verdict_comments(
+  pr_number: number,
+  repo_path: string,
+  authenticated_login: string,
+  env?: NodeJS.ProcessEnv,
+  gh_bin = "gh",
+): Promise<number> {
+  let comments: GHCommentForVerdict[];
+  try {
+    const { stdout } = await exec_async(
+      gh_bin,
+      ["pr", "view", String(pr_number), "--json", "comments", "--jq", ".comments"],
+      { cwd: repo_path, env, timeout: 15_000 },
+    );
+    const parsed: unknown = JSON.parse(stdout || "[]");
+    comments = Array.isArray(parsed) ? (parsed as GHCommentForVerdict[]) : [];
+  } catch {
+    return 0;
+  }
+
+  let n = 0;
+  for (const comment of comments) {
+    if (!comment || typeof comment.body !== "string") continue;
+    if (comment.author?.login !== authenticated_login) continue;
+    if (verdict_of(comment.body) !== null) n++;
+  }
+  return n;
+}
+
+/**
+ * Count formal `PullRequestReview` objects authored by the given login.
+ * Used to enforce the per-PR review-cycle cap in multi-dev mode (#46).
+ *
+ * Counts any review state — APPROVED / CHANGES_REQUESTED / COMMENTED /
+ * DISMISSED — because each represents a Reviewer pass through the PR. The
+ * cap is on number of passes, not on the verdict distribution.
+ *
+ * Returns 0 on any gh CLI failure.
+ */
+export async function count_reviews_by_login(
+  pr_number: number,
+  repo_path: string,
+  reviewer_login: string,
+  env?: NodeJS.ProcessEnv,
+  gh_bin = "gh",
+): Promise<number> {
+  try {
+    const { stdout } = await exec_async(
+      gh_bin,
+      ["pr", "view", String(pr_number), "--json", "reviews", "--jq", ".reviews"],
+      { cwd: repo_path, env, timeout: 15_000 },
+    );
+    const parsed: unknown = JSON.parse(stdout || "[]");
+    if (!Array.isArray(parsed)) return 0;
+    let n = 0;
+    for (const review of parsed as Array<{ author?: { login?: string } | null }>) {
+      if (review?.author?.login === reviewer_login) n++;
+    }
+    return n;
+  } catch {
+    return 0;
+  }
+}
+
 /**
  * Check if a PR has merge conflicts by inspecting its mergeable state.
  */

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -717,7 +717,19 @@ async function handle_review_completion(
     // Fall through — detect_review_outcome will use daemon's default auth
   }
 
-  const outcome = await detect_review_outcome(pr.number, repo_path, gh_token);
+  // In single-dev repos GitHub blocks `gh pr review --approve` on self-authored
+  // PRs, so Reviewer falls back to a `**Verdict:` comment. Pass
+  // `is_self_authored` so detect_review_outcome can poll comments when
+  // reviewDecision is empty. Mirrors the same resolution pr-cron.ts uses
+  // (entity.accounts.github.user). See #46.
+  const entity_match = find_entity_for_repo_full(repo_full_name, ctx.registry);
+  const github_user = entity_match?.entity.entity.accounts?.github?.user;
+  const is_self_authored = github_user != null && pr.user.login === github_user;
+
+  const outcome = await detect_review_outcome(pr.number, repo_path, {
+    gh_token,
+    is_self_authored,
+  });
 
   console.log(`[webhook] Review completed for PR #${String(pr.number)} — outcome: ${outcome}`);
 


### PR DESCRIPTION
Closes #46.

## Summary

- Daemon now reads `**Verdict: Approved**` / `**Verdict: Changes Requested**` findings comments as a fallback when GitHub's `reviewDecision` is empty and the PR is self-authored. Unblocks the autonomous build-review-merge loop in single-dev repos where `gh pr review --approve` is blocked.
- Hard cap of 3 review cycles per PR. At the cap, the daemon posts an amber alert to `#alerts` (Hunter ping) and stops spawning Builder. `escalated_at_cycle` is persisted so subsequent cron ticks stay quiet.
- Verdict source (`"review"` vs `"comment"`) is persisted on `ProcessedPR` for diagnostics.

## What lands

**§1 Comment-fallback verdict detection** — `packages/daemon/src/review-utils.ts`
- `detect_verdict_from_comments(pr, repo, login, env?, gh_bin?)` — most-recent-wins, author-filtered, case-sensitive literal-first-line match. Returns `null` on gh failure.
- `get_authenticated_login(repo, env?, gh_bin?)` — resolves `gh api user`. Returns `null` on failure so callers refuse to guess.
- `count_verdict_comments` / `count_reviews_by_login` — counters for the cycle cap.

**§2 Wired into `detect_review_outcome`** — `packages/daemon/src/actions.ts`
- New `DetectReviewOutcomeOptions` (`gh_token`, `is_self_authored`); legacy positional `gh_token` still works.
- Resolution order: PR merged → `reviewDecision` → (if empty AND self-authored AND login resolves) findings-comment → pending.
- Comment fallback is gated on `is_self_authored` so the multi-dev path stays on formal reviews only.
- New `detect_review_outcome_with_source` variant returns `{ outcome, source }` for diagnostics.

**§3 Cycle cap enforcement** — `packages/daemon/src/pr-cron.ts`
- `MAX_REVIEW_CYCLES = 3` (matches the #38 amendment).
- Single-dev: counts findings-comment verdicts. Multi-dev: counts formal reviews by Reviewer's login.
- At cap: amber alert via `alert_router.post_alert({ tier: "action_required", ... })`, no Builder spawn, `escalated_at_cycle` persisted.
- Under cap: existing Builder spawn path, cycle index added to the routine alert body (`cycle 2/3`).
- Dedup: once `escalated_at_cycle` is set, subsequent ticks log-only.

**§4 Persist verdict source** — `packages/daemon/src/persistence.ts`
- `ProcessedPR.verdict_source?: "review" | "comment"`
- `ProcessedPR.escalated_at_cycle?: number`

**§5 Tests** — three files
- `__tests__/review-utils.test.ts` (new) — 13 cases for the verdict helpers
- `__tests__/actions.test.ts` — 6 new cases for `detect_review_outcome` fallback paths
- `__tests__/pr-cron.test.ts` — 4 new cases for the cycle cap (incl. `MAX_REVIEW_CYCLES = 3` contract guard)

## Test plan

- [x] Comment fallback returns Approved when latest comment matches
- [x] Comment fallback returns Changes Requested when latest comment matches
- [x] Comment fallback returns null when no matching comment
- [x] Comment fallback ignores comments from other authors
- [x] Comment fallback uses most recent matching comment when multiple exist
- [x] `detect_review_outcome` prefers `reviewDecision` when present (regression guard)
- [x] `detect_review_outcome` falls back only when self-authored
- [x] Cycle cap: at 2 cycles, Builder spawns; at 3, alert fires + Builder does not spawn
- [x] Cycle cap doesn't re-alert across cron ticks once `escalated_at_cycle` is set
- [x] Full daemon test suite (1218 tests) green, `pnpm typecheck` clean, `pnpm lint` clean

## Out of scope (v2)

Per-repo config (`max_cycles`, `reviewer_login_override`, `opt_in_loop`), webhook fast-path for verdict comments, comment dedup when re-review feedback is identical, structured agent→daemon escalation channel.

## Dogfood

This PR ships through the same loop it's fixing. Success criterion: the *next* PR through the loop should not need manual orchestration.