### PR TITLE
fix: warn against cd && git anti-pattern in DNA skills

### DIFF
--- a/config/claude/skills/coding-dna/SKILL.md
+++ b/config/claude/skills/coding-dna/SKILL.md
@@ -726,6 +726,20 @@ The code never knows or cares that 1Password is involved. It just reads env vars
 
 Git workflow (branching rules, PR process, merge policy) is defined per-project in each repo's `CLAUDE.md`. Read it before starting work.
 
+### Git in non-cwd directories — always `git -C <path>`, never `cd <path> && git ...`
+
+When you need to run git against a repo or worktree that isn't your current working directory, use `git -C <path> <subcommand>`. **Never** emit the `cd <path> && git ...` compound shape. This rule covers every git subcommand: `git -C <path> status`, `git -C <path> worktree list`, `git -C <path> rev-parse`, `git -C <path> branch -D`, `git -C <path> push`, all of them.
+
+Why this matters more than it looks:
+
+- The Claude Code harness has a hard-coded safety backstop that intercepts `cd … && git …` compound commands with a "bare repository attacks" approval prompt — and that specific class **always** prompts, even under `--permission-mode bypassPermissions`. The bypass flag bypasses everything else; it does not bypass this one.
+- In interactive sessions this costs you a click. In pool-bot sessions (no human at the keyboard) the prompt sits unanswered, the agent treats it as a terminal condition and exits, the daemon's health check sees a dead tmux pane and restarts with `--resume`, the resumed session immediately re-emits the same compound — and you have a crash loop that ends with the bot being force-released. We have lived this (lobster-farm issue #55).
+- This is not a hypothetical pattern the model "might" emit. It is a strong organic shape from training data and shows up unprompted whenever an agent reasons about "go into the worktree and check status." Counter-prompt explicitly; the suppression is the fix.
+
+The translations are mechanical and there is always a `-C` form. If you find yourself wanting to write `cd worktrees/foo && git status`, write `git -C worktrees/foo status` instead. Same for `git worktree remove`, `git branch -D`, `git log`, every git invocation. There is no case where `cd && git` is the only option.
+
+> If you genuinely need a non-git command to run with a working directory set (e.g., `pnpm test` inside a worktree), `cd <path> && <non-git-command>` is fine — the backstop is specific to the `cd … && git …` shape. Just don't chain a git call onto it.
+
 ### Pull Requests — Draft vs. Ready
 
 **Open a draft PR when you start a feature branch.** This gives visibility (the branch and diff are trackable) without triggering review or auto-merge. Keep pushing commits as you iterate.

--- a/config/claude/skills/pr-review-merge/SKILL.md
+++ b/config/claude/skills/pr-review-merge/SKILL.md
@@ -35,6 +35,12 @@ gh pr list --repo {url} --state open --json number,title,headRefName,updatedAt
 
 When a new or updated PR is found that isn't already being processed, the daemon triggers this SOP.
 
+## Critical — never `cd <path> && git ...` in any step below
+
+PR review and merge is where worktree-touching shell commands cluster: `git worktree list`, `git worktree remove`, `git branch -D`, `git fetch`, `git rebase`, the post-merge cleanup recipe in `MEMORY.md`. Every one of these must run as `git -C <path> <subcommand>`. The `cd <path> && git ...` compound shape is intercepted by the Claude Code harness's bare-repository safety backstop, which always prompts for approval — even under `--permission-mode bypassPermissions` — and unanswered prompts in pool-bot sessions cause the agent to exit and the daemon to crash-loop on restart. Crash data from issue #55 showed these crashes cluster around PR review/merge activity specifically because this is the venue where the bad shape is most likely to be emitted.
+
+The full rationale and the universal `-C` translation rules live in `coding-dna` → "Git in non-cwd directories." Read that section if you haven't. The short version for this SOP: write `git -C worktrees/<slug> status`, never `cd worktrees/<slug> && git status`. Same for every git subcommand used in any step below, including the post-merge cleanup.
+
 ## Steps
 
 ### 0. Pre-flight check before spawning a reviewer
@@ -257,6 +263,7 @@ Cycle counting and branch detection are agent-side responsibilities for v1. A fu
 - Don't loop past 3 cycles — escalate to Hunter instead, the loop has exhausted its budget
 - Don't auto-promote staging → main — Hunter's ✅ is the only valid signal, no timeout fallback
 - Don't spawn a reviewer without running the step-0 pre-flight check — a duplicate pass on a fresh review wastes a cycle and produces conflicting findings
+- Don't emit `cd <path> && git ...` compounds anywhere in this SOP — use `git -C <path> ...` for every git invocation against a non-cwd repo or worktree (the harness backstop crash-loops pool bots; see the "Critical" callout near the top of this file)
 
 ## Worked example — pre-flight catches a duplicate
 


### PR DESCRIPTION
Closes #55.

## Summary

Adds an explicit anti-pattern callout to two DNA skills directing agents to use `git -C <path>` instead of `cd <path> && git ...` for non-cwd git invocations. The compound shape trips the Claude Code harness's bare-repository safety backstop, which prompts for approval even under `--permission-mode bypassPermissions`. Pool bots have no human to answer; the unanswered prompt causes the agent to exit, the daemon restarts with `--resume`, the resumed session re-emits the same compound, and the bot crash-loops until force-released. Issue #55 has the full crash-data trail.

## What this PR does and does not do

- **Does** add a concentrated anti-pattern callout to `coding-dna` → new "Git in non-cwd directories" section under Git & Environments. This is the universal home — auto-loads for every archetype that touches code.
- **Does** add a tighter version to `pr-review-merge` (a "Critical" callout immediately after the Trigger section, plus a complementary line in the "What NOT to Do" list). PR review and merge is the highest-incidence venue per the crash data — worktree-list, worktree-remove, branch-delete, fetch, rebase, and the post-merge cleanup recipe all cluster here.
- **Does not** touch `feature-lifecycle`. Judgment call: it contains zero git shell snippets and never mentions `cd`. Per the issue brief's guidance to avoid sprinkling the same warning across multiple skills, concentrated guidance in two well-chosen homes is more effective than nine watered-down mentions. If feature-lifecycle is later updated to include git commands, the callout should be added then.
- **Does not** implement the issue's options #1 (settings.json `cd && git` whitelist) or #2 (daemon-side rewrite layer). Both were explicitly out of scope per Hunter's direction. Option #3 — the DNA prompt-engineering pass — is what shipped here.

## Audit finding — this is a counter-prompt PR, not a search-and-replace

Pre-flight audit (pattern `cd .* && git`) against `config/claude/skills/` and `config/claude/agents/` on the pre-edit tree returned **zero matches**. The repo prompts are already clean. So the fix is not deletion of existing offenders — it is explicit counter-prompting against an organic model behavior.

The pattern `cd <path> && git ...` is a strong organic shape the model emits from training data whenever it reasons about "go into the worktree and run a git command." Counter-prompting it explicitly in the DNA is the suppression mechanism. (Post-edit, the same audit returns matches only inside the new prose itself, where the anti-pattern is referenced inside inline backticks — never as a runnable shell snippet, to avoid polluting model output.)

## Harness changelog citation

The Claude Code harness changelog at `~/.claude/cache/changelog.md:524` explicitly documents `cd <cwd> && git ...` as a specific prompt class:

> Fixed prompting for \`cd <cwd> && git ...\` on Windows when the model uses a mingw-style path

The Windows-specific entry confirms the backstop is targeted at this exact shape, not a generic compound-command rule. It is a real harness tripwire, not a paranoid extrapolation.

## Files changed

- `config/claude/skills/coding-dna/SKILL.md` (+14) — new subsection "Git in non-cwd directories — always `git -C <path>`, never `cd <path> && git ...`" inserted between Branching and Pull Requests. Explains the harness backstop, the pool-bot crash-loop chain, the universal `-C` translation, and an exception note for non-git compounds.
- `config/claude/skills/pr-review-merge/SKILL.md` (+7) — "Critical" callout immediately after the Trigger section pointing to coding-dna for full rationale, plus an additional bullet in "What NOT to Do".

## Verification caveat

The issue's stated acceptance criteria (`tmux crashed` events drop to <5% of baseline; zero `Crash loop detected` events in the following week) **cannot be measured in this PR**. This is a prompt-content change with no runtime surface, no test coverage to add, and no CI signal that would turn green or red on the fix landing. Validation is async observation over the next ~7 days against `~/.lobsterfarm/logs/daemon.log` and is owned by Karim or whoever next reviews daemon logs. Calling this out so the reviewer doesn't expect a build/test signal that does not exist for this kind of change.

## Test plan

- [ ] Visual review of the two SKILL.md diffs for tone, accuracy, and consistency with the surrounding DNA voice
- [ ] Confirm the audit finding holds: `rg "cd .* && git" config/claude/skills/ config/claude/agents/` after merge returns only the new anti-pattern prose, no executable shell snippets containing the bad shape
- [ ] Async (post-merge, ~7 days): tail `~/.lobsterfarm/logs/daemon.log` for `tmux crashed` event rate and any new `Crash loop detected` lines; expect a meaningful drop. If the rate does not drop, the next step is option #1 (settings.json whitelist) as the interim fallback the issue calls out

🤖 Generated with [Claude Code](https://claude.com/claude-code)