### PR TITLE
fix(daemon-tests): scrub LF_PENDING_FILE from test env spread

### DIFF
--- a/packages/daemon/src/__tests__/session-start-hook.test.ts
+++ b/packages/daemon/src/__tests__/session-start-hook.test.ts
@@ -42,8 +42,14 @@ try {
 
 /** Invoke the hook script with the given env. Returns stdout + exit code. */
 function run_hook(env: Record<string, string>): { stdout: string; stderr: string; code: number } {
+  // Scrub LF_PENDING_FILE from the parent process env before merging caller
+  // overrides. Without this, the daemon-parent's exported LF_PENDING_FILE leaks
+  // into the subprocess via the spread, causing the "unset" test to see the var
+  // as set. Callers that need the var pass it explicitly via the `env` argument.
+  const base = { ...process.env };
+  delete base.LF_PENDING_FILE;
   const result = spawnSync("bash", [HOOK_SCRIPT], {
-    env: { ...process.env, ...env },
+    env: { ...base, ...env },
     encoding: "utf-8",
     timeout: 5000,
   });


### PR DESCRIPTION
## Summary

- `run_hook` in `session-start-hook.test.ts` spread `process.env` directly into the spawned subprocess, causing `LF_PENDING_FILE` exported by the daemon parent to leak into every subprocess env — including the `run_hook({})` call that is supposed to test the "var is unset" path.
- The fix splits env construction into `const base = { ...process.env }`, deletes `LF_PENDING_FILE` from `base`, then merges caller overrides. Test callers that need the var pass it explicitly via the `env` argument (all existing callers already do this).
- Pre-existing `@lobster-farm/shared` not-built failures are unrelated to this change and present on `main`.

## Test plan

- [ ] `session-start-hook.test.ts` passes 10/10 with `LF_PENDING_FILE` unset
- [ ] `session-start-hook.test.ts` passes 10/10 with `LF_PENDING_FILE` set to a real file path (simulates daemon parent state — was 9/10 failing before fix)
- [ ] `biome check` on changed file exits 0
- [ ] `pnpm --filter '@lobster-farm/daemon' typecheck` exits 0

Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)