### PR TITLE
fix: point install.sh and README at hkelley44 fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Autonomous orchestration platform built on Claude Code. Turns a single machine i
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ultim88888888/lobster-farm/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/hkelley44/lobster-farm/main/install.sh | bash
 ```
 
 Then run the setup wizard:
@@ -19,7 +19,7 @@ The wizard checks for prerequisites (Claude Code, 1Password, sudo), configures y
 ### Manual install
 
 ```bash
-git clone https://github.com/ultim88888888/lobster-farm.git ~/.lobsterfarm/src
+git clone https://github.com/hkelley44/lobster-farm.git ~/.lobsterfarm/src
 cd ~/.lobsterfarm/src
 pnpm install && pnpm build
 chmod +x $(pwd)/packages/cli/dist/index.js

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # LobsterFarm installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/ultim88888888/lobster-farm/main/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/hkelley44/lobster-farm/main/install.sh | bash
 
-REPO="ultim88888888/lobster-farm"
+REPO="hkelley44/lobster-farm"
 INSTALL_DIR="$HOME/.lobsterfarm/src"
 BIN_DIR="$HOME/.local/bin"
 


### PR DESCRIPTION
## Summary
- `install.sh` lines 5 + 7 and `README.md` lines 8 + 22 hardcoded the upstream slug `ultim88888888/lobster-farm`. Per the 2026-04-28 fork transition, `hkelley44/lobster-farm` is the canonical repo.
- Three string replacements, no logic changes. Anyone running the documented one-liner today was pulling upstream and missing every fork-only change from Phase 2 onward.

## Test plan
- [x] `grep -n ultim88888888 install.sh README.md` returns no matches
- [ ] After merge: `curl -fsSL https://raw.githubusercontent.com/hkelley44/lobster-farm/main/install.sh` resolves and shows new content
- [ ] After merge: smoke test the one-liner on a fresh machine, confirm `git remote -v` points at `hkelley44/lobster-farm`

Closes #62