### PR TITLE
feat(daemon): upgrade Opus tier to 4-8, route Sonnet workloads to Opus

### DIFF
--- a/packages/daemon/src/__tests__/session.test.ts
+++ b/packages/daemon/src/__tests__/session.test.ts
@@ -31,14 +31,14 @@ describe("build_model_flags", () => {
   it("maps opus/high to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "high" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-7");
+    expect(flags).toContain("claude-opus-4-8");
     expect(flags).toContain("--effort");
     expect(flags).toContain("high");
   });
 
-  it("maps sonnet/standard to correct flags", () => {
+  it("maps sonnet/standard to opus 4-8 (sonnet tier intentionally aliased)", () => {
     const flags = build_model_flags({ model: "sonnet", think: "standard" });
-    expect(flags).toContain("claude-sonnet-4-6");
+    expect(flags).toContain("claude-opus-4-8");
     expect(flags).toContain("medium");
   });
 
@@ -52,7 +52,7 @@ describe("build_model_flags", () => {
   it("maps opus/xhigh to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "xhigh" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-7");
+    expect(flags).toContain("claude-opus-4-8");
     expect(flags).toContain("--effort");
     expect(flags).toContain("xhigh");
   });
@@ -60,7 +60,7 @@ describe("build_model_flags", () => {
   it("maps opus/max to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "max" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-7");
+    expect(flags).toContain("claude-opus-4-8");
     expect(flags).toContain("--effort");
     expect(flags).toContain("max");
   });
@@ -100,7 +100,7 @@ describe("ClaudeSessionManager", () => {
       expect(args).toContain("--agent");
       expect(args).toContain("bob"); // default builder name
       expect(args).toContain("--model");
-      expect(args).toContain("claude-opus-4-7");
+      expect(args).toContain("claude-opus-4-8");
       expect(args).toContain("--permission-mode");
       expect(args).toContain("bypassPermissions");
       expect(args).toContain("--session-id");

--- a/packages/daemon/src/models.ts
+++ b/packages/daemon/src/models.ts
@@ -1,9 +1,17 @@
 import type { ModelName, ModelTier, ThinkLevel } from "@lobster-farm/shared";
 
-/** Map abstract model names to Claude CLI model identifiers. */
+/**
+ * Map abstract model names to Claude CLI model identifiers.
+ *
+ * The `sonnet` tier intentionally resolves to Opus 4-8 — review and triage are
+ * decision-quality work where the Opus uplift is worth the rate-limit cost.
+ * The `haiku` tier stays on actual Haiku because its primary consumer is the
+ * Stop-hook heartbeat generator (every-minute one-line summaries), where Opus
+ * would 10x cost for zero perceptible quality lift.
+ */
 const MODEL_IDS: Record<ModelName, string> = {
-  opus: "claude-opus-4-7",
-  sonnet: "claude-sonnet-4-6",
+  opus: "claude-opus-4-8",
+  sonnet: "claude-opus-4-8",
   haiku: "claude-haiku-4-5-20251001",
 };
 


### PR DESCRIPTION
## Summary

Upgrades the model resolution layer to Opus 4-8 for all generative work, while keeping the Haiku tier on actual Haiku for the high-volume heartbeat path.

| Tier | Before | After | Reason |
|---|---|---|---|
| `opus` | `claude-opus-4-7` | `claude-opus-4-8` | Pure upgrade |
| `sonnet` | `claude-sonnet-4-6` | `claude-opus-4-8` | Review / triage / operator are decision-quality work — Opus uplift is worth the cost |
| `haiku` | `claude-haiku-4-5-20251001` | unchanged | Stop-hook heartbeats fire every minute per active channel; Opus would 10x the highest-volume model call for zero quality lift |

## Capacity check

Hunter is on Claude Max. At time of change his weekly usage was 2% (all models), with no Sonnet usage at all. Even a 5x increase from moving Sonnet → Opus puts total weekly utilization at ~10%. No rate-limit risk.

## Why keep Sonnet tier name but alias to Opus

Renaming `sonnet` → some new tier name would require touching every entity config (`defaults.models.review.model: sonnet`, etc.). The tier-name-to-model mapping is the single source of truth and the right place for this kind of swap; downstream config can stay untouched. If a future cheaper Sonnet matters again, swap back here with no other changes.

## Test changes

`packages/daemon/src/__tests__/session.test.ts` — updated five assertions to reflect the new model IDs. The `sonnet`-tier assertion is annotated as intentionally aliased so a future reader doesn't `git blame` and think it's a typo.

## Verification

- `pnpm install --frozen-lockfile` ✅
- `pnpm build` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ 67 files, 1221 tests passing in 8.16s

## Rollout

In-flight sessions keep their currently-spawned `claude-opus-4-7` until release/reassignment — no breakage, both models work. Daemon `lf restart` after merge picks up the new IDs for all subsequent spawns.

Closes #65.