### PR TITLE
fix(pool): verify-and-retry tmux submit to close keystroke race

### DIFF
--- a/packages/daemon/src/__tests__/inject-confirmation.test.ts
+++ b/packages/daemon/src/__tests__/inject-confirmation.test.ts
@@ -1,0 +1,109 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
+
+// ── Mocks ──
+
+vi.mock("../actions.js", () => ({
+  notify: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../persistence.js", () => ({
+  save_pool_state: vi.fn().mockResolvedValue(undefined),
+  load_pool_state: vi.fn().mockResolvedValue({
+    bots: [],
+    session_history: {},
+    avatar_state: {},
+  }),
+}));
+
+vi.mock("../sentry.js", () => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+vi.mock("../rate-limit-recovery.js", () => ({
+  scan_and_recover: vi.fn().mockReturnValue([]),
+}));
+
+// ── Tests ──
+
+/**
+ * inject_message_to_bot must propagate the submit-confirmation boolean from
+ * send_via_tmux: a success log + true return only when the submit was
+ * actually confirmed, a warning + false return when it wasn't (#65).
+ */
+describe("inject_message_to_bot submit-confirmation propagation (issue #65)", () => {
+  let temp_dir: string;
+  let config: LobsterFarmConfig;
+  let pool: BotPoolTestBase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    temp_dir = join(tmpdir(), `inject-confirm-test-${Date.now()}`);
+    config = LobsterFarmConfigSchema.parse({
+      user: { name: "Test" },
+      paths: { lobsterfarm_dir: temp_dir },
+    });
+    pool = new BotPoolTestBase(config);
+
+    // Session is alive and at the prompt — ready to receive immediately.
+    vi.spyOn(pool as unknown as Record<string, unknown>, "is_tmux_alive" as never).mockReturnValue(
+      true as never,
+    );
+    vi.spyOn(pool as unknown as Record<string, unknown>, "is_at_prompt" as never).mockReturnValue(
+      true as never,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function stub_send(result: boolean) {
+    return vi
+      .spyOn(pool as unknown as Record<string, unknown>, "send_via_tmux" as never)
+      .mockResolvedValue(result as never);
+  }
+
+  it("returns true and logs success when the submit is confirmed", async () => {
+    stub_send(true);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ok = await pool.inject_message_to_bot("pool-1", "hello");
+
+    expect(ok).toBe(true);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Injected message into pool-1"));
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns false and warns when the submit is not confirmed", async () => {
+    stub_send(false);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ok = await pool.inject_message_to_bot("pool-1", "hello");
+
+    expect(ok).toBe(false);
+    // No success log fired on an unconfirmed (likely dropped) submit.
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Injected message into pool-1"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("submit not confirmed"));
+  });
+
+  it("returns false when send_via_tmux throws", async () => {
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "send_via_tmux" as never,
+    ).mockRejectedValue(new Error("tmux send failed") as never);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ok = await pool.inject_message_to_bot("pool-1", "hello");
+
+    expect(ok).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Failed to inject message"));
+  });
+});

--- a/packages/daemon/src/__tests__/submit-retry.test.ts
+++ b/packages/daemon/src/__tests__/submit-retry.test.ts
@@ -1,0 +1,162 @@
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: vi.fn().mockImplementation(() => {
+      throw new Error("not mocked");
+    }),
+    spawn: vi.fn(),
+  };
+});
+
+import { execFileSync } from "node:child_process";
+import { send_keys_with_submit_retry } from "../pool.js";
+
+/**
+ * Build an execFileSync mock that:
+ *  - records every send-keys invocation (so we can count Enter re-sends)
+ *  - returns a scripted sequence of capture-pane outputs (one per poll)
+ *
+ * Once the scripted outputs are exhausted, the last value repeats — this lets a
+ * test simulate "input box stays stuck forever" with a single trailing value.
+ */
+function mock_pane(pane_outputs: string[], message: string) {
+  const send_keys_calls: string[][] = [];
+  let poll = 0;
+
+  (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === "tmux" && args[0] === "send-keys") {
+      send_keys_calls.push(args);
+      return "";
+    }
+    if (cmd === "tmux" && args[0] === "capture-pane") {
+      const idx = Math.min(poll, pane_outputs.length - 1);
+      poll++;
+      return pane_outputs[idx] ?? `❯ ${message}`;
+    }
+    return "";
+  });
+
+  return {
+    send_keys_calls,
+    /** Number of times Enter (with or without text) was sent. */
+    submit_count: () => send_keys_calls.length,
+    /** Number of bare-Enter re-sends: ["send-keys", "-t", <session>, "Enter"].
+     * The initial submit is ["send-keys", "-t", <session>, <message>, "Enter"]
+     * (length 5), so a length-4 call is a retry. */
+    retry_count: () => send_keys_calls.filter((a) => a.length === 4 && a[3] === "Enter").length,
+  };
+}
+
+// ── Tests ──
+
+describe("send_keys_with_submit_retry", () => {
+  const MSG = "hold until I delete the repo";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("confirms immediately when the turn starts (esc to interrupt)", async () => {
+    // Pane shows the active-generation indicator on the first poll.
+    const m = mock_pane(["✶ Thinking… (esc to interrupt)"], MSG);
+
+    const p = send_keys_with_submit_retry("pool-4", MSG, { poll_ms: 50, confirm_ms: 400 });
+    await vi.advanceTimersByTimeAsync(500);
+    expect(await p).toBe(true);
+
+    // One send (text + Enter), no retries.
+    expect(m.retry_count()).toBe(0);
+  });
+
+  it("confirms when the input box clears (text no longer present)", async () => {
+    // Pane no longer echoes the typed text → submit landed.
+    const m = mock_pane(["❯ "], MSG);
+
+    const p = send_keys_with_submit_retry("pool-4", MSG, { poll_ms: 50, confirm_ms: 400 });
+    await vi.advanceTimersByTimeAsync(500);
+    expect(await p).toBe(true);
+    expect(m.retry_count()).toBe(0);
+  });
+
+  it("re-sends Enter when text sits unsubmitted, then succeeds", async () => {
+    // First confirm window: text still in the box. After the retry Enter, the
+    // turn starts → confirmed.
+    const m = mock_pane(
+      [
+        `❯ ${MSG}`, // poll 1 — still unsubmitted
+        `❯ ${MSG}`, // poll 2 — still unsubmitted (window expires → retry Enter)
+        "✶ Working… (esc to interrupt)", // poll 3 — turn started
+      ],
+      MSG,
+    );
+
+    const p = send_keys_with_submit_retry("pool-4", MSG, {
+      poll_ms: 100,
+      confirm_ms: 150,
+      max_retries: 3,
+    });
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(await p).toBe(true);
+
+    // Exactly one bare-Enter retry was needed.
+    expect(m.retry_count()).toBe(1);
+  });
+
+  it("logs a warning when a retry was needed", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const m = mock_pane([`❯ ${MSG}`, `❯ ${MSG}`, "esc to interrupt"], MSG);
+
+    const p = send_keys_with_submit_retry("pool-4", MSG, {
+      poll_ms: 100,
+      confirm_ms: 150,
+      max_retries: 3,
+    });
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(await p).toBe(true);
+
+    expect(m.retry_count()).toBe(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("re-sending Enter"));
+    warn.mockRestore();
+  });
+
+  it("gives up after bounded retries when text never submits", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Input box stays stuck forever (single trailing value repeats).
+    const m = mock_pane([`❯ ${MSG}`], MSG);
+
+    const p = send_keys_with_submit_retry("pool-4", MSG, {
+      poll_ms: 100,
+      confirm_ms: 150,
+      max_retries: 2,
+    });
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(await p).toBe(false);
+
+    // Bounded: exactly max_retries bare-Enter re-sends, no infinite loop.
+    expect(m.retry_count()).toBe(2);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Submit never confirmed"));
+    warn.mockRestore();
+  });
+
+  it("does not warn on the happy path", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mock_pane(["esc to interrupt"], MSG);
+
+    const p = send_keys_with_submit_retry("pool-4", MSG, { poll_ms: 50, confirm_ms: 400 });
+    await vi.advanceTimersByTimeAsync(500);
+    expect(await p).toBe(true);
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/packages/daemon/src/__tests__/submit-retry.test.ts
+++ b/packages/daemon/src/__tests__/submit-retry.test.ts
@@ -52,6 +52,31 @@ function mock_pane(pane_outputs: string[], message: string) {
   };
 }
 
+/**
+ * Build an execFileSync mock where `send-keys` succeeds but every `capture-pane`
+ * THROWS — simulating a dead/killed session whose pane can't be read. The
+ * retry loop must treat this as indeterminate (never a confirmed submit).
+ */
+function mock_pane_capture_fails() {
+  const send_keys_calls: string[][] = [];
+
+  (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === "tmux" && args[0] === "send-keys") {
+      send_keys_calls.push(args);
+      return "";
+    }
+    if (cmd === "tmux" && args[0] === "capture-pane") {
+      throw new Error("can't find pane: session not found");
+    }
+    return "";
+  });
+
+  return {
+    send_keys_calls,
+    retry_count: () => send_keys_calls.filter((a) => a.length === 4 && a[3] === "Enter").length,
+  };
+}
+
 // ── Tests ──
 
 describe("send_keys_with_submit_retry", () => {
@@ -157,6 +182,30 @@ describe("send_keys_with_submit_retry", () => {
     expect(await p).toBe(true);
 
     expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("does not false-positive confirm when the pane read fails — retries then gives up", async () => {
+    // Capture-pane throws on every poll (dead/killed session). A failed read is
+    // indeterminate, NOT "input box empty → submitted": the loop must keep
+    // retrying and then give up rather than reporting a phantom success (#65).
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const m = mock_pane_capture_fails();
+
+    const p = send_keys_with_submit_retry("pool-4", MSG, {
+      poll_ms: 100,
+      confirm_ms: 150,
+      max_retries: 2,
+    });
+    await vi.advanceTimersByTimeAsync(3000);
+
+    // Must NOT report a false-positive confirmation.
+    expect(await p).toBe(false);
+    // Bounded: exactly max_retries bare-Enter re-sends, no infinite loop.
+    expect(m.retry_count()).toBe(2);
+    // The pane-unreadable failure is surfaced, and the give-up is logged.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Pane read failed"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("could not confirm submit"));
     warn.mockRestore();
   });
 });

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -2653,10 +2653,17 @@ export class BotPool extends EventEmitter {
     }
 
     if (this.is_at_prompt(tmux_session)) {
+      let confirmed: boolean;
       try {
-        await this.send_via_tmux(tmux_session, message);
+        confirmed = await this.send_via_tmux(tmux_session, message);
       } catch (err) {
         console.warn(`[pool] Failed to inject message into ${tmux_session}: ${String(err)}`);
+        return false;
+      }
+      if (!confirmed) {
+        console.warn(
+          `[pool] Injected message into ${tmux_session} but submit not confirmed — message may be dropped`,
+        );
         return false;
       }
       console.log(`[pool] Injected message into ${tmux_session}`);
@@ -2695,9 +2702,11 @@ export class BotPool extends EventEmitter {
   }
 
   /** Send a message to a tmux session via send-keys, verifying the submit
-   * landed and retrying the Enter if the input box is left unsubmitted (#65). */
-  private async send_via_tmux(session_name: string, message: string): Promise<void> {
-    await send_keys_with_submit_retry(session_name, message);
+   * landed and retrying the Enter if the input box is left unsubmitted (#65).
+   * Returns true only when the submit was confirmed; false on exhausted
+   * retries or an unreadable pane (message likely dropped). */
+  private async send_via_tmux(session_name: string, message: string): Promise<boolean> {
+    return send_keys_with_submit_retry(session_name, message);
   }
 
   /** Drain queued messages for bots that are now at the prompt. Called from health check. */
@@ -2711,16 +2720,26 @@ export class BotPool extends EventEmitter {
         continue;
       }
       if (this.is_at_prompt(session)) {
+        let confirmed = 0;
         try {
           for (const message of messages) {
-            await this.send_via_tmux(session, message);
+            if (await this.send_via_tmux(session, message)) confirmed++;
           }
-          this.pending_injections.delete(session);
-          console.log(
-            `[pool] Delivered ${String(messages.length)} queued message(s) to ${session}`,
-          );
         } catch (err) {
           console.warn(`[pool] Failed to deliver queued messages to ${session}: ${String(err)}`);
+        }
+        // Drop the queue regardless — the bounded submit retries are exhausted,
+        // and re-queueing a likely-dead session would just loop the same failure.
+        // Dead-session recovery is issue #66's job.
+        this.pending_injections.delete(session);
+        const failed = messages.length - confirmed;
+        if (confirmed > 0) {
+          console.log(`[pool] Delivered ${String(confirmed)} queued message(s) to ${session}`);
+        }
+        if (failed > 0) {
+          console.warn(
+            `[pool] ${String(failed)} queued message(s) to ${session} unconfirmed — may be dropped`,
+          );
         }
       }
       // Still busy — keep queued, will retry next cycle
@@ -2758,8 +2777,14 @@ export class BotPool extends EventEmitter {
       // Bot is ready with an undelivered pending file — deliver it
       try {
         const prompt = `A user messaged you earlier but the message wasn't delivered. Read ${pending_path} for their message and respond to them.`;
-        await this.send_via_tmux(bot.tmux_session, prompt);
-        console.log(`[pool] Drained pending file for ${bot.tmux_session} via health check`);
+        const confirmed = await this.send_via_tmux(bot.tmux_session, prompt);
+        if (confirmed) {
+          console.log(`[pool] Drained pending file for ${bot.tmux_session} via health check`);
+        } else {
+          console.warn(
+            `[pool] Drained pending file for ${bot.tmux_session} but submit not confirmed — may be dropped`,
+          );
+        }
         // Clean up shortly after — Claude has the prompt and will read it within seconds.
         // Keep this well under the 30s health-check interval to prevent self-re-delivery
         // on the next tick.

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -236,6 +236,106 @@ export async function wait_for_bot_ready_with_retries(
   return false;
 }
 
+// ── Keystroke injection with submit-race retry ──
+
+/** Full visible pane content. Empty string on failure. */
+function capture_pane(tmux_session: string): string {
+  try {
+    return execFileSync("tmux", ["capture-pane", "-t", tmux_session, "-p"], {
+      encoding: "utf-8",
+      timeout: 2000,
+    });
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Inject a message into a tmux pane via send-keys and verify the submit landed.
+ *
+ * tmux `send-keys` for the message text and the subsequent Enter are racy: if
+ * the Enter arrives before the input is committed (or during a redraw), it's
+ * dropped and the text sits in the input box, unsubmitted — the agent never
+ * starts a turn and the message is silently lost (issue #65).
+ *
+ * After sending text + Enter, this polls the pane for a bounded window to
+ * confirm the turn actually started. A submit is considered confirmed when the
+ * pane shows an active-turn indicator ("esc to interrupt") OR the input box no
+ * longer contains the message text. If the text is still sitting unsubmitted
+ * after the poll window, a bare Enter is re-sent — up to `max_retries` times.
+ *
+ * Logs a warning whenever a retry was needed so submit-race frequency is
+ * measurable in the daemon logs.
+ *
+ * @param tmux_session - tmux session name (e.g., "pool-4")
+ * @param message - message text to type into the input box
+ * @param opts.poll_ms - poll interval while waiting for confirmation (default 200ms)
+ * @param opts.confirm_ms - how long to wait for confirmation per attempt (default 800ms)
+ * @param opts.max_retries - max bare-Enter retries after the initial submit (default 3)
+ * @returns true if the submit was confirmed, false if it remained unconfirmed
+ */
+export async function send_keys_with_submit_retry(
+  tmux_session: string,
+  message: string,
+  opts?: { poll_ms?: number; confirm_ms?: number; max_retries?: number },
+): Promise<boolean> {
+  const poll_ms = opts?.poll_ms ?? 200;
+  const confirm_ms = opts?.confirm_ms ?? 800;
+  const max_retries = opts?.max_retries ?? 3;
+
+  // Send the message text and the initial submit in one send-keys call.
+  execFileSync("tmux", ["send-keys", "-t", tmux_session, message, "Enter"], {
+    stdio: "ignore",
+    timeout: 5000,
+  });
+
+  // A turn started if the status bar shows the active-generation indicator, or
+  // the input box no longer echoes the message text we just typed. Scan the
+  // whole pane — long input wraps across lines, so a last-line check would
+  // falsely report "submitted" for wrapped text still sitting in the box.
+  const submit_confirmed = (): boolean => {
+    const pane = capture_pane(tmux_session);
+    if (pane.includes("esc to interrupt")) return true;
+    return !pane.includes(message);
+  };
+
+  for (let retry = 0; retry <= max_retries; retry++) {
+    const deadline = Date.now() + confirm_ms;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, poll_ms));
+      if (submit_confirmed()) {
+        if (retry > 0) {
+          console.warn(
+            `[pool] Submit confirmed for ${tmux_session} after ${String(retry)} retry(ies) — keystroke submit race`,
+          );
+        }
+        return true;
+      }
+    }
+
+    // Still unsubmitted after the poll window — re-send a bare Enter (bounded).
+    if (retry < max_retries) {
+      console.warn(
+        `[pool] Submit not confirmed for ${tmux_session} (text still in input box) — re-sending Enter (retry ${String(retry + 1)}/${String(max_retries)})`,
+      );
+      try {
+        execFileSync("tmux", ["send-keys", "-t", tmux_session, "Enter"], {
+          stdio: "ignore",
+          timeout: 5000,
+        });
+      } catch (err) {
+        console.warn(`[pool] Re-send Enter failed for ${tmux_session}: ${String(err)}`);
+        return false;
+      }
+    }
+  }
+
+  console.warn(
+    `[pool] Submit never confirmed for ${tmux_session} after ${String(max_retries)} retries — message may be dropped`,
+  );
+  return false;
+}
+
 // ── Claude Code JSONL session tracking ──
 
 /**
@@ -1570,7 +1670,7 @@ export class BotPool extends EventEmitter {
       this.cleanup_session_history();
 
       // Deliver any queued messages to bots that are now at the prompt
-      this.drain_pending_injections();
+      await this.drain_pending_injections();
 
       // Safety net: recover undelivered legacy .txt pending files left by
       // any older spawn path. The canonical SessionStart-hook injection
@@ -2526,7 +2626,7 @@ export class BotPool extends EventEmitter {
     }
 
     if (this.is_at_prompt(tmux_session)) {
-      this.send_via_tmux(tmux_session, message);
+      await this.send_via_tmux(tmux_session, message);
       console.log(`[pool] Injected message into ${tmux_session}`);
       return true;
     }
@@ -2562,16 +2662,14 @@ export class BotPool extends EventEmitter {
     }
   }
 
-  /** Send a message to a tmux session via send-keys. */
-  private send_via_tmux(session_name: string, message: string): void {
-    execFileSync("tmux", ["send-keys", "-t", session_name, message, "Enter"], {
-      stdio: "ignore",
-      timeout: 5000,
-    });
+  /** Send a message to a tmux session via send-keys, verifying the submit
+   * landed and retrying the Enter if the input box is left unsubmitted (#65). */
+  private async send_via_tmux(session_name: string, message: string): Promise<void> {
+    await send_keys_with_submit_retry(session_name, message);
   }
 
   /** Drain queued messages for bots that are now at the prompt. Called from health check. */
-  private drain_pending_injections(): void {
+  private async drain_pending_injections(): Promise<void> {
     for (const [session, messages] of this.pending_injections) {
       if (!this.is_tmux_alive(session)) {
         this.pending_injections.delete(session);
@@ -2583,7 +2681,7 @@ export class BotPool extends EventEmitter {
       if (this.is_at_prompt(session)) {
         try {
           for (const message of messages) {
-            this.send_via_tmux(session, message);
+            await this.send_via_tmux(session, message);
           }
           this.pending_injections.delete(session);
           console.log(
@@ -2628,7 +2726,7 @@ export class BotPool extends EventEmitter {
       // Bot is ready with an undelivered pending file — deliver it
       try {
         const prompt = `A user messaged you earlier but the message wasn't delivered. Read ${pending_path} for their message and respond to them.`;
-        this.send_via_tmux(bot.tmux_session, prompt);
+        await this.send_via_tmux(bot.tmux_session, prompt);
         console.log(`[pool] Drained pending file for ${bot.tmux_session} via health check`);
         // Clean up shortly after — Claude has the prompt and will read it within seconds.
         // Keep this well under the 30s health-check interval to prevent self-re-delivery

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -238,15 +238,20 @@ export async function wait_for_bot_ready_with_retries(
 
 // ── Keystroke injection with submit-race retry ──
 
-/** Full visible pane content. Empty string on failure. */
-function capture_pane(tmux_session: string): string {
+/**
+ * Full visible pane content, or `null` if the capture itself failed (dead/killed
+ * session, timeout). A failed read is NOT the same as a genuinely empty pane —
+ * callers must treat `null` as "indeterminate" and never infer submit success
+ * from it, or a dead session would silently mask a dropped message (#65).
+ */
+function capture_pane(tmux_session: string): string | null {
   try {
     return execFileSync("tmux", ["capture-pane", "-t", tmux_session, "-p"], {
       encoding: "utf-8",
       timeout: 2000,
     });
   } catch {
-    return "";
+    return null;
   }
 }
 
@@ -283,18 +288,40 @@ export async function send_keys_with_submit_retry(
   const confirm_ms = opts?.confirm_ms ?? 800;
   const max_retries = opts?.max_retries ?? 3;
 
-  // Send the message text and the initial submit in one send-keys call.
-  execFileSync("tmux", ["send-keys", "-t", tmux_session, message, "Enter"], {
-    stdio: "ignore",
-    timeout: 5000,
-  });
+  // Send the message text and the initial submit in one send-keys call. If the
+  // session died between the at-prompt check and now, this throws — log and
+  // treat as not-confirmed so the retry/give-up path handles it rather than
+  // aborting the surrounding health-check iteration mid-loop.
+  try {
+    execFileSync("tmux", ["send-keys", "-t", tmux_session, message, "Enter"], {
+      stdio: "ignore",
+      timeout: 5000,
+    });
+  } catch (err) {
+    console.warn(`[pool] Initial send-keys failed for ${tmux_session}: ${String(err)}`);
+    return false;
+  }
 
   // A turn started if the status bar shows the active-generation indicator, or
   // the input box no longer echoes the message text we just typed. Scan the
   // whole pane — long input wraps across lines, so a last-line check would
   // falsely report "submitted" for wrapped text still sitting in the box.
+  //
+  // A failed pane read (null) is indeterminate, NOT confirmed — returning true
+  // there would fail-open and silently mask a dropped message on a dead session.
+  // Warn once (not per-poll) so a dead session doesn't spam the log.
+  let warned_pane_read = false;
   const submit_confirmed = (): boolean => {
     const pane = capture_pane(tmux_session);
+    if (pane === null) {
+      if (!warned_pane_read) {
+        warned_pane_read = true;
+        console.warn(
+          `[pool] Pane read failed for ${tmux_session} — cannot confirm submit (treating as not confirmed)`,
+        );
+      }
+      return false;
+    }
     if (pane.includes("esc to interrupt")) return true;
     return !pane.includes(message);
   };
@@ -331,7 +358,7 @@ export async function send_keys_with_submit_retry(
   }
 
   console.warn(
-    `[pool] Submit never confirmed for ${tmux_session} after ${String(max_retries)} retries — message may be dropped`,
+    `[pool] Submit never confirmed for ${tmux_session} after ${String(max_retries)} retries — could not confirm submit (pane unreadable or input stuck, session may be dead); message may be dropped`,
   );
   return false;
 }
@@ -2626,7 +2653,12 @@ export class BotPool extends EventEmitter {
     }
 
     if (this.is_at_prompt(tmux_session)) {
-      await this.send_via_tmux(tmux_session, message);
+      try {
+        await this.send_via_tmux(tmux_session, message);
+      } catch (err) {
+        console.warn(`[pool] Failed to inject message into ${tmux_session}: ${String(err)}`);
+        return false;
+      }
       console.log(`[pool] Injected message into ${tmux_session}`);
       return true;
     }


### PR DESCRIPTION
## Summary
Inbound messages were injected into a pool bot's tmux pane via `send-keys` (text + Enter), but the Enter occasionally got dropped if it arrived before the input was committed or during a redraw. The text landed in the input box and sat there unsubmitted — the agent never started a turn and the message was silently dropped on an otherwise-healthy bot (real incident: pool-4 / #rafa-homepage, `hold until I delete the repo`).

This adds a verify-and-retry submit:
- New `send_keys_with_submit_retry()` sends text + Enter, then polls `capture-pane` for a bounded window to confirm the turn started (`esc to interrupt` present) **or** the input box no longer contains the typed text.
- If the text is still sitting unsubmitted after the window, re-sends a bare `Enter` — with **bounded** retries (default 3), never an infinite loop.
- A failed pane read is treated as **indeterminate (not confirmed)**, so a dead/unreadable session never fails open to a phantom success.
- Logs a `console.warn` whenever a retry was needed (and a final warning if the submit never confirms), so submit-race frequency is measurable in the daemon logs.
- The daemon's `send_via_tmux` injection path now routes through it, covering all three delivery sites: immediate inject, queued-injection drain, and the legacy pending-file drain.
- `send_via_tmux` now **propagates the submit-confirmation boolean** instead of discarding it: `inject_message_to_bot` only logs success / returns `true` on a confirmed submit (warns + returns `false` otherwise), and the drain paths only log "Delivered …" for messages that actually confirmed. The queue-deletion behavior is unchanged — after the bounded retries are exhausted the queued message is dropped rather than re-queued (dead-session recovery is #66's job); the change is honest logs, not new control flow.

The text-presence check scans the **full** pane (not just the last line) so long input that wraps across lines isn't falsely reported as submitted.

## Test plan
- [x] `pnpm build` green (shared package built first)
- [x] `pnpm typecheck` green
- [x] `pnpm test` green — 1231 passed (69 files)
- [x] `pnpm lint` (biome) clean
- [x] `submit-retry.test.ts` (7 cases) covers: immediate confirm via `esc to interrupt`, confirm via cleared input box, re-send Enter then succeed, warning logged on retry, bounded give-up after N retries, no warning on the happy path, and no false-positive confirm when the pane read fails. Pane-capture is mocked to simulate "text still present" vs "submitted".
- [x] `inject-confirmation.test.ts` (3 cases) covers submit-confirmation propagation: `inject_message_to_bot` returns `true` + logs success only on a confirmed submit, returns `false` + warns when unconfirmed, and returns `false` when the send throws.

Closes #65

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>