### PR TITLE
fix(pool): health-check assigned bots on restart to repair half-spawns

### DIFF
--- a/packages/daemon/src/__tests__/pool-restart-healthcheck.test.ts
+++ b/packages/daemon/src/__tests__/pool-restart-healthcheck.test.ts
@@ -1,0 +1,254 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PoolBot } from "../pool.js";
+import type { EntityRegistry } from "../registry.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
+
+// notify() makes a Discord webhook call — mock it so reconcile_assigned_health()
+// can be asserted on without touching the network. Keep the rest of actions.js
+// intact so pool.ts's other (transitive) imports still resolve. vi.hoisted lets
+// the hoisted vi.mock() factory reference the spy.
+const { notify_mock } = vi.hoisted(() => ({ notify_mock: vi.fn(async () => {}) }));
+vi.mock("../actions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../actions.js")>();
+  return { ...actual, notify: notify_mock };
+});
+
+let temp_dir: string;
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
+  });
+}
+
+function make_entity_config(entity_id: string, channel_ids: string[]): EntityConfig {
+  return {
+    entity: {
+      id: entity_id,
+      name: `Test ${entity_id}`,
+      description: "",
+      status: "active",
+      repos: [],
+      accounts: {},
+      channels: {
+        category_id: "",
+        list: channel_ids.map((id) => ({ type: "general" as const, id })),
+      },
+      memory: { path: "/tmp/memory", auto_extract: true },
+      secrets: { vault: "1password", vault_name: `entity-${entity_id}` },
+    },
+  };
+}
+
+function make_registry(entities: EntityConfig[]): EntityRegistry {
+  const map = new Map<string, EntityConfig>();
+  for (const e of entities) map.set(e.entity.id, e);
+  return {
+    get: (id: string) => map.get(id),
+    get_all: () => [...map.values()],
+    get_active: () => [...map.values()].filter((e) => e.entity.status === "active"),
+    count: () => map.size,
+  } as unknown as EntityRegistry;
+}
+
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    session_confirmed: true,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    assigned_at: null,
+    state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
+    last_avatar_archetype: null,
+    last_avatar_set_at: null,
+    ...overrides,
+  };
+}
+
+/** Test pool that lets us drive tmux liveness per-session and inject bots. */
+class TestBotPool extends BotPoolTestBase {
+  /** Map of tmux session name → alive. Defaults to dead (post-crash). */
+  private alive = new Map<string, boolean>();
+
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+
+  get_bots(): PoolBot[] {
+    return (this as unknown as { bots: PoolBot[] }).bots;
+  }
+
+  set_tmux_alive(session: string, alive: boolean): void {
+    this.alive.set(session, alive);
+  }
+
+  protected override is_tmux_alive(session_name: string): boolean {
+    return this.alive.get(session_name) ?? false;
+  }
+}
+
+describe("reconcile_assigned_health (issue #66)", () => {
+  let pool: TestBotPool;
+
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "pool-restart-hc-"));
+    notify_mock.mockClear();
+
+    pool = new TestBotPool(make_config());
+    (pool as unknown as { registry: EntityRegistry }).registry = make_registry([
+      make_entity_config("healthydogs", ["chan-foods"]),
+    ]);
+
+    // Stub spawn-path side effects so no real tmux/Discord work happens.
+    for (const method of [
+      "kill_tmux",
+      "write_access_json",
+      "set_bot_nickname",
+      "set_bot_avatar",
+      "persist",
+      "resolve_github_token_ref",
+    ] as const) {
+      vi.spyOn(pool as unknown as Record<string, unknown>, method as never).mockImplementation(
+        (() => undefined) as never,
+      );
+    }
+    // restart_crashed_session pre-flights the JSONL — treat sessions as present.
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "check_session_jsonl_exists_anywhere" as never,
+    ).mockResolvedValue(true as never);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
+  });
+
+  it("(a) leaves an assigned bot with a live tmux session untouched", async () => {
+    const start_tmux = vi
+      .spyOn(pool as unknown as Record<string, unknown>, "start_tmux" as never)
+      .mockResolvedValue(undefined as never);
+
+    pool.inject_bots([
+      make_bot({
+        id: 3,
+        state: "assigned",
+        channel_id: "chan-foods",
+        entity_id: "healthydogs",
+        archetype: "planner",
+        session_id: "sess-live",
+      }),
+    ]);
+    pool.set_tmux_alive("pool-3", true);
+
+    await pool.reconcile_assigned_health();
+
+    // Healthy bot — no respawn, no alert, state unchanged.
+    expect(start_tmux).not.toHaveBeenCalled();
+    expect(notify_mock).not.toHaveBeenCalled();
+    expect(pool.get_bots()[0]!.state).toBe("assigned");
+  });
+
+  it("(b) respawns an assigned bot whose tmux session is dead", async () => {
+    const start_tmux = vi
+      .spyOn(pool as unknown as Record<string, unknown>, "start_tmux" as never)
+      .mockResolvedValue(undefined as never);
+
+    pool.inject_bots([
+      make_bot({
+        id: 3,
+        state: "assigned",
+        channel_id: "chan-foods",
+        entity_id: "healthydogs",
+        archetype: "planner",
+        session_id: "sess-abc",
+      }),
+    ]);
+    pool.set_tmux_alive("pool-3", false); // half-spawned: assigned but dead
+
+    await pool.reconcile_assigned_health();
+
+    // Respawned via the existing restart path (resumes the confirmed session).
+    expect(start_tmux).toHaveBeenCalledTimes(1);
+    const bot = pool.get_bots()[0]!;
+    expect(bot.state).toBe("assigned");
+    expect(bot.channel_id).toBe("chan-foods");
+    // The reused restart path posts its own "auto-restarted" success alert, but
+    // the "could not be revived" failure alert must NOT fire.
+    const revive_failed = notify_mock.mock.calls.some(
+      (call) => typeof call[1] === "string" && call[1].includes("could not be revived"),
+    );
+    expect(revive_failed).toBe(false);
+  });
+
+  it("(c) emits an alert when the bot cannot be revived", async () => {
+    // Make the respawn fail — restart_crashed_session frees the bot, then
+    // reconcile_assigned_health alerts that the channel went dark.
+    vi.spyOn(pool as unknown as Record<string, unknown>, "start_tmux" as never).mockRejectedValue(
+      new Error("tmux spawn failed") as never,
+    );
+
+    pool.inject_bots([
+      make_bot({
+        id: 3,
+        state: "assigned",
+        channel_id: "chan-foods",
+        entity_id: "healthydogs",
+        archetype: "planner",
+        session_id: "sess-abc",
+      }),
+    ]);
+    pool.set_tmux_alive("pool-3", false);
+
+    await pool.reconcile_assigned_health();
+
+    // Bot freed by the restart-failure path...
+    expect(pool.get_bots()[0]!.state).toBe("free");
+    // ...and surfaced via #alerts so the channel doesn't go silently dark.
+    expect(notify_mock).toHaveBeenCalledTimes(1);
+    const [channel, message] = notify_mock.mock.calls[0]!;
+    expect(channel).toBe("alerts");
+    expect(message).toContain("Pool bot 3");
+    expect(message).toContain("could not be revived");
+  });
+
+  it("ignores parked and free bots — only repairs assigned-but-dead", async () => {
+    const start_tmux = vi
+      .spyOn(pool as unknown as Record<string, unknown>, "start_tmux" as never)
+      .mockResolvedValue(undefined as never);
+
+    pool.inject_bots([
+      make_bot({ id: 1, state: "free" }),
+      make_bot({
+        id: 2,
+        state: "parked",
+        channel_id: "chan-foods",
+        entity_id: "healthydogs",
+        archetype: "planner",
+        session_id: "sess-parked",
+      }),
+    ]);
+    pool.set_tmux_alive("pool-1", false);
+    pool.set_tmux_alive("pool-2", false);
+
+    await pool.reconcile_assigned_health();
+
+    // Parked bots resume on next message; free bots have nothing to repair.
+    expect(start_tmux).not.toHaveBeenCalled();
+    expect(notify_mock).not.toHaveBeenCalled();
+    expect(pool.get_bots().find((b) => b.id === 2)!.state).toBe("parked");
+  });
+});

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -216,6 +216,12 @@ async function main(): Promise<void> {
 
   if (discord_connected) {
     await pool.resume_parked_bots();
+
+    // Repair bots that came back assigned-but-dead after the restart (issue #66).
+    // Runs after resume so legitimate resume candidates have already respawned;
+    // anything still assigned with no live tmux is a half-spawn that would
+    // silently drop every message to its channel.
+    await pool.reconcile_assigned_health();
   }
 
   // Initialize Commander (persistent Claude Code session with Discord channel)

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1045,6 +1045,75 @@ export class BotPool extends EventEmitter {
     }
   }
 
+  /**
+   * Post-restart health check: repair bots that came back assigned-but-dead.
+   *
+   * The drain+restart cycle can leave a bot marked `assigned` to a channel with
+   * NO live tmux session behind it — typically when the bot's session was
+   * unconfirmed at drain time, so it persisted with `session=none` and never
+   * qualified as a resume candidate. The bot listens (access.json points at the
+   * channel) but no Claude process is running, so every message is silently
+   * dropped (issue #66).
+   *
+   * For each assigned bot whose `tmux has-session` check fails, we respawn a
+   * fresh session through the existing `restart_crashed_session()` path (which
+   * resumes a confirmed session when one exists, otherwise spawns fresh). If a
+   * bot can't be revived, we alert #alerts so the channel doesn't go silently
+   * dark.
+   *
+   * Call AFTER `resume_parked_bots()` so legitimate resume candidates have
+   * already had their chance — anything still assigned-but-dead here is a
+   * genuine half-spawn that needs repair.
+   */
+  async reconcile_assigned_health(): Promise<void> {
+    // Snapshot the bot list — restart_crashed_session() mutates state but never
+    // adds/removes bots, so this stays valid for the whole pass. A dead bot is
+    // only ever repaired once (it becomes assigned-with-live-tmux or freed).
+    const half_spawned = this.bots.filter(
+      (b) => b.state === "assigned" && b.channel_id && !this.is_tmux_alive(b.tmux_session),
+    );
+    if (half_spawned.length === 0) return;
+
+    console.warn(
+      `[pool] Post-restart health check: ${String(half_spawned.length)} assigned bot(s) have no live tmux — repairing`,
+    );
+
+    for (const bot of half_spawned) {
+      const entity_id = bot.entity_id;
+      const channel_id = bot.channel_id;
+      const archetype = bot.archetype;
+      console.warn(
+        `[pool] pool-${String(bot.id)} came back assigned with a dead tmux session ` +
+          `(channel: ${channel_id ?? "none"}, session: ${bot.session_id?.slice(0, 8) ?? "none"}) — respawning`,
+      );
+
+      // restart_crashed_session() owns the spawn path: it pre-flights the JSONL,
+      // resumes when possible, writes access.json, and alerts #alerts on success.
+      // On failure it frees the bot, so we detect that below to alert.
+      await this.restart_crashed_session(bot);
+
+      // If the bot is still assigned, the respawn succeeded. Otherwise it was
+      // freed by the restart-failure path and the channel is now dark — alert.
+      if (bot.state !== "assigned") {
+        const label = this.channel_label(entity_id, channel_id);
+        console.error(
+          `[pool] pool-${String(bot.id)} could not be revived after restart — channel ${label} is dark`,
+        );
+        try {
+          await notify(
+            "alerts",
+            `\ud83d\udd34 Pool bot ${String(bot.id)} (${archetype ?? "unknown"}) came back dead after restart and could not be revived for ${entity_id ?? "unknown"}/${label}. Channel is unattended — check daemon logs.`,
+            entity_id ? this.registry?.get(entity_id) : undefined,
+          );
+        } catch (notify_err) {
+          console.warn(
+            `[pool] Failed to alert #alerts for un-revivable pool-${String(bot.id)}: ${String(notify_err)}`,
+          );
+        }
+      }
+    }
+  }
+
   /** Assign a pool bot to a channel with a specific archetype.
    *
    * If `pending_message` is provided, the daemon writes it to a JSON file and
@@ -1944,14 +2013,11 @@ export class BotPool extends EventEmitter {
       });
 
       // Wrap notify separately — an alert failure should not undo a successful restart
-      const channel_label =
-        entity_config?.entity.channels.list.find((ch) => ch.id === channel_id)?.purpose ??
-        channel_id ??
-        entity_id;
+      const label = this.channel_label(entity_id, channel_id);
       try {
         await notify(
           "alerts",
-          `\u26a0\ufe0f Pool bot ${String(bot.id)} (${archetype}) crashed and was auto-restarted for ${entity_id}/${channel_label}`,
+          `\u26a0\ufe0f Pool bot ${String(bot.id)} (${archetype}) crashed and was auto-restarted for ${entity_id}/${label}`,
           entity_config,
         );
       } catch (notify_err) {
@@ -2036,14 +2102,11 @@ export class BotPool extends EventEmitter {
 
     // Alert outside the release/event flow — a notify() failure must not
     // prevent the crash_loop event or skip remaining bots in the health check.
-    const channel_label =
-      entity_config?.entity.channels.list.find((ch) => ch.id === channel_id)?.purpose ??
-      channel_id ??
-      "unknown";
+    const label = this.channel_label(entity_id, channel_id);
     try {
       await notify(
         "alerts",
-        `\ud83d\udd34 Pool bot ${String(bot.id)} crash loop detected for ${entity_id ?? "unknown"}/${channel_label} — released. Check daemon logs.`,
+        `\ud83d\udd34 Pool bot ${String(bot.id)} crash loop detected for ${entity_id ?? "unknown"}/${label} — released. Check daemon logs.`,
         entity_config,
       );
     } catch (notify_err) {
@@ -2531,6 +2594,17 @@ export class BotPool extends EventEmitter {
 
   /** Look up the github_token_ref for an entity from the registry.
    * Returns the 1Password reference string if configured, or null. */
+  /** Human-readable label for a channel in #alerts messages: the channel's
+   * configured purpose if known, else the raw id, else "unknown". */
+  private channel_label(entity_id: string | null, channel_id: string | null): string {
+    const entity_config = entity_id ? this.registry?.get(entity_id) : undefined;
+    return (
+      entity_config?.entity.channels.list.find((ch) => ch.id === channel_id)?.purpose ??
+      channel_id ??
+      "unknown"
+    );
+  }
+
   private resolve_github_token_ref(entity_id: string): string | null {
     if (!this.registry) return null;
     const entity_config = this.registry.get(entity_id);

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -2592,8 +2592,6 @@ export class BotPool extends EventEmitter {
     });
   }
 
-  /** Look up the github_token_ref for an entity from the registry.
-   * Returns the 1Password reference string if configured, or null. */
   /** Human-readable label for a channel in #alerts messages: the channel's
    * configured purpose if known, else the raw id, else "unknown". */
   private channel_label(entity_id: string | null, channel_id: string | null): string {
@@ -2605,6 +2603,8 @@ export class BotPool extends EventEmitter {
     );
   }
 
+  /** Look up the github_token_ref for an entity from the registry.
+   * Returns the 1Password reference string if configured, or null. */
   private resolve_github_token_ref(entity_id: string): string | null {
     if (!this.registry) return null;
     const entity_config = this.registry.get(entity_id);


### PR DESCRIPTION
## Summary
A drain+restart that catches a pool bot mid-work could leave it marked **assigned** to a channel with **no live tmux session and `session=none`** — the bot listens via `access.json` but no Claude process is running, so every message to that channel is silently dropped (issue #66). This happens when the bot's session was unconfirmed at drain time: it persists with `session_id=null` and never qualifies as a resume candidate, so `resume_parked_bots()` skips it.

- Add `reconcile_assigned_health()` to `BotPool`, run once after `resume_parked_bots()` on daemon startup.
- It health-checks every `assigned` bot via `tmux has-session` (reusing `is_tmux_alive`). Any with a dead session is respawned through the **existing** `restart_crashed_session()` path (resume a confirmed session when present, otherwise spawn fresh) — no duplicated spawn logic.
- If a bot can't be revived, emit a `#alerts` notification via the existing `notify()` router so the channel surfaces instead of going silently dark.
- Extract a small `channel_label()` helper to dedupe the alert-label resolution shared across the crash-restart, crash-loop, and new health-check paths.

The repair is bounded (one pass over a snapshot, each dead bot repaired exactly once → becomes assigned-with-live-tmux or freed) and cannot spawn duplicate sessions for a channel. Healthy bots (live tmux) and parked/free bots are left untouched — parked bots still resume on next message as before.

The "unconfirmed after 60000ms — leaving unpersisted" path noted in the issue is the root cause of the half-spawn; this health-check catches and repairs the resulting assigned-but-dead state without rearchitecting session confirmation.

## Test plan
New `pool-restart-healthcheck.test.ts` (mocks `tmux has-session`, the spawn path, and `notify`):
- [x] (a) assigned bot with **live** tmux → left alone (no respawn, no alert)
- [x] (b) assigned bot with **dead** tmux → respawned via the restart path, stays assigned
- [x] (c) respawn fails → bot freed and `#alerts` notification emitted
- [x] parked/free bots ignored — only assigned-but-dead is repaired
- [x] `pnpm build && pnpm typecheck && pnpm test` all green (67 files / 1221 tests)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)
